### PR TITLE
Fix custom preset settings isolation

### DIFF
--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -23,7 +23,7 @@ class MM_Settings {
         register_setting( 'mm_settings', 'mm_default_preset', array( 'type' => 'string', 'sanitize_callback' => 'sanitize_text_field', 'default' => 'classic' ) );
         register_setting( 'mm_settings', 'mm_max_drinks', array( 'type' => 'integer', 'sanitize_callback' => 'absint', 'default' => 25 ) );
         register_setting( 'mm_settings', 'mm_show_abv', array( 'type' => 'boolean', 'sanitize_callback' => array( $this, 'sanitize_bool' ), 'default' => 1 ) );
-        register_setting( 'mm_settings', 'mm_custom_presets', array( 'type' => 'array', 'sanitize_callback' => array( $this, 'sanitize_custom_presets' ), 'default' => array() ) );
+        register_setting( 'mm_custom_presets_settings', 'mm_custom_presets', array( 'type' => 'array', 'sanitize_callback' => array( $this, 'sanitize_custom_presets' ), 'default' => array() ) );
     }
     public function sanitize_unit( $val ) {
         $allowed = array( 'ml', 'oz', 'shot', 'nip' );
@@ -126,7 +126,7 @@ class MM_Settings {
             </table>
             <h3><?php esc_html_e( 'Add preset', 'margarita-measurements' ); ?></h3>
             <form method="post" action="options.php">
-                <?php settings_fields( 'mm_settings' ); wp_nonce_field( 'mm_custom_preset_nonce', 'mm_custom_preset_nonce' ); ?>
+                <?php settings_fields( 'mm_custom_presets_settings' ); wp_nonce_field( 'mm_custom_preset_nonce', 'mm_custom_preset_nonce' ); ?>
                 <table class="form-table" role="presentation">
                     <tr><th><label for="mm_custom_label"><?php esc_html_e( 'Label', 'margarita-measurements' ); ?></label></th><td><input id="mm_custom_label" name="mm_custom_presets[new][label]" type="text" required /></td></tr>
                     <tr><th><label for="mm_custom_tequila"><?php esc_html_e( 'Tequila ml', 'margarita-measurements' ); ?></label></th><td><input id="mm_custom_tequila" name="mm_custom_presets[new][tequila_ml]" type="number" min="0" step="0.1" value="60" /></td></tr>


### PR DESCRIPTION
### Motivation
- Prevent saving a custom preset from unintentionally resetting unrelated admin options by isolating the custom presets into their own Settings API option group (the form previously posted to `mm_settings` while only including `mm_custom_presets[...]`, which caused other registered settings to be updated from empty POST values). 

### Description
- Register `mm_custom_presets` under a new option group (`mm_custom_presets_settings`) and update the Add Preset form to call `settings_fields( 'mm_custom_presets_settings' )` so preset saves no longer interact with `mm_unit`, `mm_max_drinks`, or `mm_show_abv` (changes in `includes/class-settings.php`).

### Testing
- Ran a PHP syntax check with `php -l includes/class-settings.php`, which passed; unit tests (`phpunit -c tests/phpunit.xml`) were not executed because `phpunit` is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2dcde41570832ba0f4bbcd9ce45657)