### PR TITLE
v2.4.0: Flavours, shortcode attributes, clipboard polish & dark mode

### DIFF
--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -1,16 +1,56 @@
-.mm-wrap { border: 1px solid #e5e7eb; padding: 1rem; border-radius: .5rem; background: #fff; }
+.mm-wrap {
+    --mm-accent: #111827;
+    --mm-accent-hover: #374151;
+    --mm-bg: #ffffff;
+    --mm-surface: #fafafa;
+    --mm-border: #e5e7eb;
+    --mm-text: #111827;
+    --mm-text-muted: #6b7280;
+    --mm-error: #b91c1c;
+    border: 1px solid var(--mm-border);
+    padding: 1rem;
+    border-radius: .5rem;
+    background: var(--mm-bg);
+    color: var(--mm-text);
+}
+.mm-title { margin-top: 0; }
 .mm-row { display:flex; gap: .5rem; align-items:center; margin-bottom: .5rem; }
 .mm-row > label { width: 140px; }
-.mm-fieldset { border:1px dashed #e5e7eb; padding:.5rem .75rem; border-radius:.5rem; margin-bottom:.75rem; }
+.mm-wrap select,
+.mm-wrap input[type="number"] { background: var(--mm-bg); color: var(--mm-text); border: 1px solid var(--mm-border); border-radius: .375rem; padding: .35rem .45rem; }
+.mm-fieldset { border:1px dashed var(--mm-border); padding:.5rem .75rem; border-radius:.5rem; margin-bottom:.75rem; }
 .mm-radio { margin-right: 1rem; }
 .mm-details { margin:.5rem 0; }
 .mm-grid-3 { display:grid; grid-template-columns: repeat(3, minmax(0,1fr)); gap:.75rem; }
-.mm-btn { background:#111827; color:#fff; border:0; padding:.5rem .75rem; border-radius:.375rem; cursor:pointer; }
-.mm-btn:hover { opacity:.9; }
+.mm-btn,
+.mm-btn-secondary { background: var(--mm-accent); color:#fff; border:0; padding:.5rem .75rem; border-radius:.375rem; cursor:pointer; }
+.mm-btn:hover,
+.mm-btn-secondary:hover { background: var(--mm-accent-hover); }
+.mm-btn-secondary { background: transparent; color: var(--mm-accent); border: 1px solid var(--mm-border); }
+.mm-btn-secondary:hover { color: #fff; }
 .mm-loading { padding:.5rem; }
+.mm-error { color: var(--mm-error); }
 .mm-results { margin-top: .75rem; }
-.mm-card { border:1px solid #e5e7eb; border-radius:.5rem; padding:.75rem; background:#fafafa; }
+.mm-results a,
+.mm-results strong { color: var(--mm-text); }
+.mm-card { border:1px solid var(--mm-border); border-radius:.5rem; padding:.75rem; background: var(--mm-surface); }
 .mm-card h3 { margin-top:0; }
 .mm-actions { display:flex; gap:.5rem; margin-top:.5rem; }
-.mm-help { color:#6b7280; font-size:.9em; }
+.mm-help,
+.mm-note { color: var(--mm-text-muted); font-size:.9em; }
+@media (prefers-color-scheme: dark) {
+    .mm-wrap {
+        --mm-accent: #facc15;
+        --mm-accent-hover: #fde047;
+        --mm-bg: #111827;
+        --mm-surface: #1f2937;
+        --mm-border: #374151;
+        --mm-text: #f9fafb;
+        --mm-text-muted: #d1d5db;
+        --mm-error: #fca5a5;
+    }
+    .mm-btn { color: #111827; }
+    .mm-btn:hover { color: #111827; }
+    .mm-btn-secondary:hover { color: #111827; }
+}
 @media (max-width:640px){ .mm-grid-3 { grid-template-columns: 1fr; } .mm-row { flex-direction:column; align-items:flex-start; } .mm-row > label { width:auto; } }

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -1,12 +1,81 @@
 (function($){
-    $(document).on('change', '#mm_mode', function(){
-        $('.mm-pitcher-row').toggle( $(this).val() === 'pitcher' );
+    function esc(text) {
+        return $('<div>').text(text == null ? '' : text).html();
+    }
+
+    function titleCase(text) {
+        text = text || '';
+        return text.charAt(0).toUpperCase() + text.slice(1);
+    }
+
+    function ingredientRows(d) {
+        var sfx = d.suffix;
+        var rows = [];
+        var tequilaLabel = (d.quantities.tequila && d.quantities.tequila.label) ? d.quantities.tequila.label : 'Tequila';
+        if (d.quantities.tequila && d.quantities.tequila.ml > 0) {
+            rows.push([tequilaLabel, d.quantities.tequila.display + ' ' + sfx]);
+        }
+        rows.push(['Citrus juice', d.quantities.citrus.display + ' ' + sfx]);
+        if (d.quantities.triple && d.quantities.triple.ml > 0) {
+            rows.push(['Triple sec', d.quantities.triple.display + ' ' + sfx]);
+        }
+        if (d.quantities.agave && d.quantities.agave.ml > 0) {
+            rows.push(['Agave syrup', d.quantities.agave.display + ' ' + sfx]);
+        }
+        if (d.quantities.flavour && d.quantities.flavour.ml > 0) {
+            rows.push([d.quantities.flavour.label, d.quantities.flavour.display + ' ' + sfx]);
+        }
+        return rows;
+    }
+
+    function copyText(d) {
+        var lines = ['Margarita Recipe'];
+        lines.push('Preset: ' + (d.preset_label || titleCase(d.preset)));
+        if (d.flavour && d.flavour.key !== 'none') {
+            lines.push('Flavour: ' + d.flavour.label);
+        }
+        lines.push(d.mode === 'pitcher' ? 'Pitcher: ' + d.pitcher_ml + ' ml total' : 'Drinks: ' + d.drinks);
+        lines.push('Ingredients:');
+        ingredientRows(d).forEach(function(row){ lines.push('- ' + row[0] + ': ' + row[1]); });
+        if (typeof d.abv !== 'undefined') {
+            lines.push('Estimated ABV: ' + d.abv + '%');
+        }
+        if (d.salt_rim) {
+            lines.push('Salt rim: ~' + d.salt_rim.grams + 'g (' + d.salt_rim.tsps + ' tsp) — ' + d.salt_rim.wet_dry + ' rim');
+        }
+        lines.push('Made with Margarita Measurements for WordPress');
+        return lines.join('\n');
+    }
+
+    function writeClipboard(text) {
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+            return navigator.clipboard.writeText(text);
+        }
+        return new Promise(function(resolve, reject){
+            var textarea = document.createElement('textarea');
+            textarea.value = text;
+            textarea.setAttribute('readonly', 'readonly');
+            textarea.style.position = 'fixed';
+            textarea.style.left = '-9999px';
+            document.body.appendChild(textarea);
+            textarea.select();
+            try {
+                if (document.execCommand('copy')) { resolve(); } else { reject(); }
+            } catch (e) {
+                reject(e);
+            }
+            document.body.removeChild(textarea);
+        });
+    }
+
+    $(document).on('change', 'select[name="mode"]', function(){
+        $(this).closest('.mm-form').find('.mm-pitcher-row').toggle( $(this).val() === 'pitcher' );
     });
 
     $(document).on('submit', '.mm-form', function(e){
         e.preventDefault();
         var $form = $(this);
-        var $results = $('#mm-results');
+        var $results = $form.siblings('.mm-results');
         $results.html('<div class="mm-loading" role="status" aria-live="polite">Calculating…</div>');
 
         var data = $form.serializeArray().reduce(function(obj, item) {
@@ -27,67 +96,71 @@
                 return;
             }
             var d = resp.data;
-            window._mmLastResult = d;
-            var sfx = d.suffix;
+            $results.data('mm-result', d);
             var title = d.mode === 'pitcher'
-                ? 'Pitcher (' + d.pitcher_ml + ' ml total) — ' + d.preset.charAt(0).toUpperCase() + d.preset.slice(1)
-                : 'Batch for ' + d.drinks + ' drink(s) — ' + d.preset.charAt(0).toUpperCase() + d.preset.slice(1);
+                ? 'Pitcher (' + esc(d.pitcher_ml) + ' ml total) — ' + esc(d.preset_label || titleCase(d.preset))
+                : 'Batch for ' + esc(d.drinks) + ' drink(s) — ' + esc(d.preset_label || titleCase(d.preset));
+            if (d.flavour && d.flavour.key !== 'none') {
+                title += ' · ' + esc(d.flavour.label);
+            }
             var html = '';
             html += '<div class="mm-card">';
             html += '<h3>' + title + '</h3>';
             html += '<ul>';
-            html += '<li><strong>Tequila:</strong> ' + d.quantities.tequila.display + ' ' + sfx + '</li>';
-            html += '<li><strong>Citrus juice:</strong> ' + d.quantities.citrus.display + ' ' + sfx + '</li>';
-            if (d.quantities.triple.ml > 0) {
-                html += '<li><strong>Triple sec:</strong> ' + d.quantities.triple.display + ' ' + sfx + '</li>';
-            }
-            if (d.quantities.agave.ml > 0) {
-                html += '<li><strong>Agave syrup:</strong> ' + d.quantities.agave.display + ' ' + sfx + '</li>';
-            }
+            ingredientRows(d).forEach(function(row){
+                html += '<li><strong>' + esc(row[0]) + ':</strong> ' + esc(row[1]) + '</li>';
+            });
             html += '</ul>';
+            if (d.flavour && d.flavour.heat_modifier) {
+                html += '<p class="mm-note">🌶 Heat-friendly flavour: jalapeño tequila assumed.</p>';
+            }
             if (typeof d.abv !== 'undefined') {
-                html += '<p><em>Estimated ABV:</em> ' + d.abv + '%</p>';
+                html += '<p><em>Estimated ABV:</em> ' + esc(d.abv) + '%</p>';
+            } else if (d.flavour && d.flavour.no_alcohol) {
+                html += '<p><em>Alcohol-free:</em> no ABV estimate shown.</p>';
             }
             if (d.salt_rim) {
-                html += '<p>🧂 <strong>Salt rim:</strong> ~' + d.salt_rim.grams + 'g (' + d.salt_rim.tsps + ' tsp) — ' + d.salt_rim.wet_dry + ' rim</p>';
+                html += '<p>🧂 <strong>Salt rim:</strong> ~' + esc(d.salt_rim.grams) + 'g (' + esc(d.salt_rim.tsps) + ' tsp) — ' + esc(d.salt_rim.wet_dry) + ' rim</p>';
             }
             html += '<div class="mm-actions">';
-            html += '<button class="mm-print" type="button">Print</button>';
-            html += '<button class="mm-copy" type="button">Copy</button>';
+            html += '<button class="mm-print mm-btn-secondary" type="button">Print</button>';
+            html += '<button class="mm-copy mm-btn-secondary" type="button">Copy</button>';
             html += '</div>';
             html += '</div>';
             $results.html(html);
-
-            $results.find('.mm-copy').on('click', function(){
-                var text = $results.text();
-                navigator.clipboard.writeText(text).then(function(){ alert('Copied!'); });
-            });
-            $results.find('.mm-print').on('click', function(){
-                var d = window._mmLastResult;
-                if (!d) return;
-                var rows = [
-                    ['Tequila', d.quantities.tequila.display + ' ' + d.suffix],
-                    ['Citrus juice', d.quantities.citrus.display + ' ' + d.suffix]
-                ];
-                if (d.quantities.triple.ml > 0) { rows.push(['Triple sec', d.quantities.triple.display + ' ' + d.suffix]); }
-                if (d.quantities.agave.ml > 0) { rows.push(['Agave syrup', d.quantities.agave.display + ' ' + d.suffix]); }
-                var tableRows = rows.map(function(r){ return '<tr><td><strong>' + r[0] + '</strong></td><td>' + r[1] + '</td></tr>'; }).join('');
-                var saltLine = d.salt_rim ? '<tr><td><strong>Salt (rim)</strong></td><td>~' + d.salt_rim.grams + 'g (' + d.salt_rim.tsps + ' tsp)</td></tr>' : '';
-                var modeLabel = d.mode === 'pitcher' ? 'Pitcher — ' + d.pitcher_ml + ' ml total' : d.drinks + ' drink(s)';
-                var html = '<div id="mm-print-frame">'
-                    + '<h2>🍋 Margarita Recipe</h2>'
-                    + '<p class="mm-print-meta">' + d.preset.charAt(0).toUpperCase() + d.preset.slice(1) + ' · ' + modeLabel + '</p>'
-                    + '<table><tbody>' + tableRows + saltLine + '</tbody></table>'
-                    + (d.abv ? '<p>Estimated ABV: <strong>' + d.abv + '%</strong></p>' : '')
-                    + '<p class="mm-print-footer">Generated by Margarita Measurements · ' + new Date().toLocaleDateString() + '</p>'
-                    + '</div>';
-                $('#mm-print-frame').remove();
-                $('body').append(html);
-                window.print();
-                $('#mm-print-frame').remove();
-            });
         }).fail(function(){
             $results.html('<div class="mm-error">Network error. Please try again.</div>');
         });
+    });
+
+    $(document).on('click', '.mm-copy', function(){
+        var $btn = $(this);
+        var d = $btn.closest('.mm-results').data('mm-result');
+        if (!d) { return; }
+        var original = $btn.text();
+        writeClipboard(copyText(d)).then(function(){
+            $btn.text('✓ Copied!');
+            window.setTimeout(function(){ $btn.text(original); }, 2000);
+        });
+    });
+
+    $(document).on('click', '.mm-print', function(){
+        var d = $(this).closest('.mm-results').data('mm-result');
+        if (!d) { return; }
+        var tableRows = ingredientRows(d).map(function(r){ return '<tr><td><strong>' + esc(r[0]) + '</strong></td><td>' + esc(r[1]) + '</td></tr>'; }).join('');
+        var saltLine = d.salt_rim ? '<tr><td><strong>Salt (rim)</strong></td><td>~' + esc(d.salt_rim.grams) + 'g (' + esc(d.salt_rim.tsps) + ' tsp)</td></tr>' : '';
+        var modeLabel = d.mode === 'pitcher' ? 'Pitcher — ' + esc(d.pitcher_ml) + ' ml total' : esc(d.drinks) + ' drink(s)';
+        var flavourLabel = d.flavour && d.flavour.key !== 'none' ? ' · ' + esc(d.flavour.label) : '';
+        var html = '<div id="mm-print-frame">'
+            + '<h2>🍋 Margarita Recipe</h2>'
+            + '<p class="mm-print-meta">' + esc(d.preset_label || titleCase(d.preset)) + flavourLabel + ' · ' + modeLabel + '</p>'
+            + '<table><tbody>' + tableRows + saltLine + '</tbody></table>'
+            + (typeof d.abv !== 'undefined' ? '<p>Estimated ABV: <strong>' + esc(d.abv) + '%</strong></p>' : '')
+            + '<p class="mm-print-footer">Generated by Margarita Measurements · ' + esc(new Date().toLocaleDateString()) + '</p>'
+            + '</div>';
+        $('#mm-print-frame').remove();
+        $('body').append(html);
+        window.print();
+        $('#mm-print-frame').remove();
     });
 })(jQuery);

--- a/includes/class-ajax.php
+++ b/includes/class-ajax.php
@@ -10,23 +10,31 @@ class MM_Ajax {
     public function handle() {
         check_ajax_referer( 'mm_nonce', 'nonce' );
         $max  = (int) get_option( 'mm_max_drinks', 25 );
-        $mode = sanitize_key( $_POST['mode'] ?? 'drinks' );
+        $mode = sanitize_key( wp_unslash( $_POST['mode'] ?? 'drinks' ) );
         $args = array(
-            'preset'     => sanitize_key( $_POST['preset'] ?? 'classic' ),
-            'drinks'     => min( max( 1, absint( $_POST['drinks'] ?? 1 ) ), $max ),
-            'pitcher_ml' => min( 5000, max( 100, (float) ( $_POST['pitcher_ml'] ?? 1000 ) ) ),
-            'unit'       => sanitize_text_field( $_POST['unit'] ?? get_option( 'mm_unit', 'ml' ) ),
+            'preset'     => sanitize_key( wp_unslash( $_POST['preset'] ?? 'classic' ) ),
+            'drinks'     => min( max( 1, absint( wp_unslash( $_POST['drinks'] ?? 1 ) ) ), $max ),
+            'pitcher_ml' => min( 5000, max( 100, (float) wp_unslash( $_POST['pitcher_ml'] ?? 1000 ) ) ),
+            'unit'       => sanitize_key( wp_unslash( $_POST['unit'] ?? get_option( 'mm_unit', 'ml' ) ) ),
+            'flavour'    => sanitize_key( wp_unslash( $_POST['flavour'] ?? 'none' ) ),
             'wet_rim'    => ! empty( $_POST['wet_rim'] ),
         );
         $calc            = MM_Plugin::instance()->calc;
         $allowed_presets = array_keys( $calc->list_presets() );
+        $allowed_units   = array( 'ml', 'oz', 'shot', 'nip' );
         $args['preset']  = in_array( $args['preset'], $allowed_presets, true ) ? $args['preset'] : 'classic';
+        $args['unit']    = in_array( $args['unit'], $allowed_units, true ) ? $args['unit'] : get_option( 'mm_unit', 'ml' );
+        $args['flavour'] = $calc->normalise_flavour_key( $args['flavour'] );
+        $mode            = in_array( $mode, array( 'drinks', 'pitcher' ), true ) ? $mode : 'drinks';
         $data            = 'pitcher' === $mode ? $calc->pitcher( $args ) : $calc->batch( $args );
         foreach ( $data['quantities'] as &$v ) {
             if ( is_array( $v ) && isset( $v['display'] ) ) { $v['display'] = round( $v['display'], 2 ); }
         }
         unset( $v );
         $data['abv'] = round( $data['abv'], 1 );
+        if ( empty( $_POST['show_abv'] ) || ! empty( $data['flavour']['no_alcohol'] ) ) {
+            unset( $data['abv'] );
+        }
         wp_send_json_success( $data );
     }
     public function delete_preset() {

--- a/includes/class-calculator.php
+++ b/includes/class-calculator.php
@@ -48,6 +48,31 @@ class MM_Calculator {
         return array_merge( $this->presets, is_array( $custom ) ? $custom : array() );
     }
 
+
+    public function list_flavours() {
+        return array(
+            'none'       => array( 'label' => __( 'None', 'margarita-measurements' ) ),
+            'spicy'      => array( 'label' => __( 'Spicy', 'margarita-measurements' ), 'tequila_label' => __( 'Jalapeño tequila', 'margarita-measurements' ), 'heat_modifier' => 0.05 ),
+            'mango'      => array( 'label' => __( 'Mango', 'margarita-measurements' ), 'ingredient_key' => 'mango_nectar', 'ingredient_label' => __( 'Mango nectar', 'margarita-measurements' ), 'ingredient_ml' => 30.0 ),
+            'watermelon' => array( 'label' => __( 'Watermelon', 'margarita-measurements' ), 'ingredient_key' => 'watermelon_juice', 'ingredient_label' => __( 'Watermelon juice', 'margarita-measurements' ), 'ingredient_ml' => 40.0, 'citrus_delta_ml' => -10.0 ),
+            'strawberry' => array( 'label' => __( 'Strawberry', 'margarita-measurements' ), 'ingredient_key' => 'strawberry_puree', 'ingredient_label' => __( 'Strawberry purée', 'margarita-measurements' ), 'ingredient_ml' => 25.0 ),
+            'coconut'    => array( 'label' => __( 'Coconut', 'margarita-measurements' ), 'ingredient_key' => 'coconut_cream', 'ingredient_label' => __( 'Coconut cream', 'margarita-measurements' ), 'ingredient_ml' => 20.0, 'agave_override_ml' => 0.0 ),
+            'virgin'     => array( 'label' => __( 'Virgin', 'margarita-measurements' ), 'tequila_label' => __( 'Sparkling water', 'margarita-measurements' ), 'replace_tequila' => true, 'no_alcohol' => true ),
+        );
+    }
+
+    public function normalise_flavour_key( $key ) {
+        $key      = sanitize_key( $key );
+        $flavours = $this->list_flavours();
+        return isset( $flavours[ $key ] ) ? $key : 'none';
+    }
+
+    public function get_flavour( $key ) {
+        $flavours = $this->list_flavours();
+        $key      = $this->normalise_flavour_key( $key );
+        return $flavours[ $key ];
+    }
+
     public function ml_to_unit( $ml, $unit ) {
         switch ( $unit ) {
             case 'oz': return $ml / 29.5735;
@@ -87,73 +112,157 @@ class MM_Calculator {
         );
     }
 
+    protected function apply_flavour( $amounts, $flavour_key, $scale ) {
+        $flavour_key = $this->normalise_flavour_key( $flavour_key );
+        $flavour     = $this->get_flavour( $flavour_key );
+        $extra_ml    = 0.0;
+        $extra       = null;
+
+        if ( ! empty( $flavour['replace_tequila'] ) ) {
+            $amounts['tequila_ml'] = 0.0;
+            $amounts['triple_ml']  = 0.0;
+        }
+
+        if ( isset( $flavour['citrus_delta_ml'] ) ) {
+            $amounts['citrus_ml'] = max( 0.0, $amounts['citrus_ml'] + ( (float) $flavour['citrus_delta_ml'] * $scale ) );
+        }
+
+        if ( isset( $flavour['agave_override_ml'] ) ) {
+            $amounts['agave_ml'] = (float) $flavour['agave_override_ml'] * $scale;
+        }
+
+        if ( isset( $flavour['ingredient_key'], $flavour['ingredient_ml'] ) ) {
+            $extra_ml = (float) $flavour['ingredient_ml'] * $scale;
+            $extra    = array(
+                'key'     => $flavour['ingredient_key'],
+                'label'   => $flavour['ingredient_label'] ?? $flavour['label'],
+                'ml'      => $extra_ml,
+                'display' => 0,
+            );
+        }
+
+        if ( ! empty( $flavour['replace_tequila'] ) ) {
+            $extra_ml = $amounts['original_tequila_ml'] + $amounts['original_triple_ml'];
+            $extra    = array(
+                'key'     => 'sparkling_water',
+                'label'   => $flavour['tequila_label'] ?? __( 'Sparkling water', 'margarita-measurements' ),
+                'ml'      => $extra_ml,
+                'display' => 0,
+            );
+        }
+
+        $amounts['extra_ml'] = $extra_ml;
+        $amounts['extra']    = $extra;
+        return $amounts;
+    }
+
+    protected function flavour_meta( $flavour_key ) {
+        $flavour_key = $this->normalise_flavour_key( $flavour_key );
+        $flavour     = $this->get_flavour( $flavour_key );
+        return array(
+            'key'           => $flavour_key,
+            'label'         => $flavour['label'],
+            'tequila_label' => $flavour['tequila_label'] ?? __( 'Tequila', 'margarita-measurements' ),
+            'heat_modifier' => $flavour['heat_modifier'] ?? 0,
+            'no_alcohol'    => ! empty( $flavour['no_alcohol'] ),
+        );
+    }
+
     public function batch( $args ) {
-        $preset_key = isset( $args['preset'] ) ? $args['preset'] : 'classic';
-        $drinks     = max( 1, (int) ( $args['drinks'] ?? 1 ) );
-        $unit       = $args['unit'] ?? 'ml';
-        $wet_rim    = ! empty( $args['wet_rim'] );
-        $presets    = $this->list_presets();
-        $preset     = $presets[ $preset_key ] ?? $this->presets['classic'];
-        $teq_ml     = $preset['tequila_ml'] * $drinks;
-        $citr_ml    = $preset['citrus_ml'] * $drinks;
-        $trip_ml    = $preset['triple_ml'] * $drinks;
-        $agav_ml    = $preset['agave_ml'] * $drinks;
-        $ice_mul    = $preset['ice_factor'];
-        $total_ml   = $teq_ml + $citr_ml + $trip_ml + $agav_ml;
-        $abv        = $this->abv_estimate( $teq_ml, $trip_ml, $total_ml, $preset['triple_abv'] ?? 0.40 );
+        $preset_key  = isset( $args['preset'] ) ? $args['preset'] : 'classic';
+        $drinks      = max( 1, (int) ( $args['drinks'] ?? 1 ) );
+        $unit        = $args['unit'] ?? 'ml';
+        $wet_rim     = ! empty( $args['wet_rim'] );
+        $flavour_key = $this->normalise_flavour_key( $args['flavour'] ?? 'none' );
+        $presets     = $this->list_presets();
+        $preset      = $presets[ $preset_key ] ?? $this->presets['classic'];
+        $amounts     = array(
+            'original_tequila_ml' => $preset['tequila_ml'] * $drinks,
+            'original_triple_ml'  => $preset['triple_ml'] * $drinks,
+            'tequila_ml'          => $preset['tequila_ml'] * $drinks,
+            'citrus_ml'           => $preset['citrus_ml'] * $drinks,
+            'triple_ml'           => $preset['triple_ml'] * $drinks,
+            'agave_ml'            => $preset['agave_ml'] * $drinks,
+        );
+        $amounts     = $this->apply_flavour( $amounts, $flavour_key, $drinks );
+        $ice_mul     = $preset['ice_factor'];
+        $total_ml    = $amounts['tequila_ml'] + $amounts['citrus_ml'] + $amounts['triple_ml'] + $amounts['agave_ml'] + $amounts['extra_ml'];
+        $meta        = $this->flavour_meta( $flavour_key );
+        $abv         = $meta['no_alcohol'] ? 0 : $this->abv_estimate( $amounts['tequila_ml'], $amounts['triple_ml'], $total_ml, $preset['triple_abv'] ?? 0.40 );
+        if ( ! empty( $amounts['extra'] ) ) {
+            $amounts['extra']['display'] = $this->ml_to_unit( $amounts['extra']['ml'], $unit );
+        }
 
         return array(
             'mode'       => 'drinks',
             'drinks'     => $drinks,
             'unit'       => $unit,
             'quantities' => array(
-                'tequila'        => array( 'ml' => $teq_ml, 'display' => $this->ml_to_unit( $teq_ml, $unit ) ),
-                'citrus'         => array( 'ml' => $citr_ml, 'display' => $this->ml_to_unit( $citr_ml, $unit ) ),
-                'triple'         => array( 'ml' => $trip_ml, 'display' => $this->ml_to_unit( $trip_ml, $unit ) ),
-                'agave'          => array( 'ml' => $agav_ml, 'display' => $this->ml_to_unit( $agav_ml, $unit ) ),
+                'tequila'        => array( 'ml' => $amounts['tequila_ml'], 'display' => $this->ml_to_unit( $amounts['tequila_ml'], $unit ), 'label' => $meta['tequila_label'] ),
+                'citrus'         => array( 'ml' => $amounts['citrus_ml'], 'display' => $this->ml_to_unit( $amounts['citrus_ml'], $unit ) ),
+                'triple'         => array( 'ml' => $amounts['triple_ml'], 'display' => $this->ml_to_unit( $amounts['triple_ml'], $unit ) ),
+                'agave'          => array( 'ml' => $amounts['agave_ml'], 'display' => $this->ml_to_unit( $amounts['agave_ml'], $unit ) ),
+                'flavour'        => $amounts['extra'],
                 'ice_multiplier' => $ice_mul,
                 'total_ml'       => $total_ml,
             ),
             'salt_rim'   => $this->salt_rim( $drinks, $wet_rim ),
             'abv'        => $abv,
             'preset'     => $preset_key,
+            'preset_label' => $preset['label'] ?? ucfirst( $preset_key ),
+            'flavour'    => $meta,
             'suffix'     => $this->unit_suffix( $unit ),
         );
     }
 
     public function pitcher( $args ) {
-        $pitcher_ml = min( 5000.0, max( 100.0, (float) ( $args['pitcher_ml'] ?? 1000.0 ) ) );
-        $preset_key = $args['preset'] ?? 'classic';
-        $presets    = $this->list_presets();
-        $preset     = $presets[ $preset_key ] ?? $this->presets['classic'];
-        $unit       = $args['unit'] ?? 'ml';
-        $wet_rim    = ! empty( $args['wet_rim'] );
-        $total_parts = $preset['tequila_ml'] + $preset['citrus_ml'] + $preset['triple_ml'] + $preset['agave_ml'];
-        if ( $total_parts <= 0 ) {
-            $total_parts = 90.0;
+        $pitcher_ml  = min( 5000.0, max( 100.0, (float) ( $args['pitcher_ml'] ?? 1000.0 ) ) );
+        $preset_key  = $args['preset'] ?? 'classic';
+        $presets     = $this->list_presets();
+        $preset      = $presets[ $preset_key ] ?? $this->presets['classic'];
+        $unit        = $args['unit'] ?? 'ml';
+        $wet_rim     = ! empty( $args['wet_rim'] );
+        $flavour_key = $this->normalise_flavour_key( $args['flavour'] ?? 'none' );
+        $base_parts  = $preset['tequila_ml'] + $preset['citrus_ml'] + $preset['triple_ml'] + $preset['agave_ml'];
+        if ( $base_parts <= 0 ) {
+            $base_parts = 90.0;
         }
-        $scale   = $pitcher_ml / $total_parts;
-        $teq_ml  = $preset['tequila_ml'] * $scale;
-        $citr_ml = $preset['citrus_ml'] * $scale;
-        $trip_ml = $preset['triple_ml'] * $scale;
-        $agav_ml = $preset['agave_ml'] * $scale;
-        $abv     = $this->abv_estimate( $teq_ml, $trip_ml, $pitcher_ml, $preset['triple_abv'] ?? 0.40 );
-        $drinks  = max( 1, (int) round( $pitcher_ml / 90 ) );
+        $scale   = $pitcher_ml / $base_parts;
+        $amounts = array(
+            'original_tequila_ml' => $preset['tequila_ml'] * $scale,
+            'original_triple_ml'  => $preset['triple_ml'] * $scale,
+            'tequila_ml'          => $preset['tequila_ml'] * $scale,
+            'citrus_ml'           => $preset['citrus_ml'] * $scale,
+            'triple_ml'           => $preset['triple_ml'] * $scale,
+            'agave_ml'            => $preset['agave_ml'] * $scale,
+        );
+        $amounts = $this->apply_flavour( $amounts, $flavour_key, $scale );
+        $total_ml = $amounts['tequila_ml'] + $amounts['citrus_ml'] + $amounts['triple_ml'] + $amounts['agave_ml'] + $amounts['extra_ml'];
+        $meta     = $this->flavour_meta( $flavour_key );
+        $abv      = $meta['no_alcohol'] ? 0 : $this->abv_estimate( $amounts['tequila_ml'], $amounts['triple_ml'], $total_ml, $preset['triple_abv'] ?? 0.40 );
+        $drinks   = max( 1, (int) round( $pitcher_ml / 90 ) );
+        if ( ! empty( $amounts['extra'] ) ) {
+            $amounts['extra']['display'] = $this->ml_to_unit( $amounts['extra']['ml'], $unit );
+        }
 
         return array(
             'mode'       => 'pitcher',
             'pitcher_ml' => $pitcher_ml,
             'unit'       => $unit,
             'quantities' => array(
-                'tequila' => array( 'ml' => $teq_ml, 'display' => $this->ml_to_unit( $teq_ml, $unit ) ),
-                'citrus'  => array( 'ml' => $citr_ml, 'display' => $this->ml_to_unit( $citr_ml, $unit ) ),
-                'triple'  => array( 'ml' => $trip_ml, 'display' => $this->ml_to_unit( $trip_ml, $unit ) ),
-                'agave'   => array( 'ml' => $agav_ml, 'display' => $this->ml_to_unit( $agav_ml, $unit ) ),
+                'tequila' => array( 'ml' => $amounts['tequila_ml'], 'display' => $this->ml_to_unit( $amounts['tequila_ml'], $unit ), 'label' => $meta['tequila_label'] ),
+                'citrus'  => array( 'ml' => $amounts['citrus_ml'], 'display' => $this->ml_to_unit( $amounts['citrus_ml'], $unit ) ),
+                'triple'  => array( 'ml' => $amounts['triple_ml'], 'display' => $this->ml_to_unit( $amounts['triple_ml'], $unit ) ),
+                'agave'   => array( 'ml' => $amounts['agave_ml'], 'display' => $this->ml_to_unit( $amounts['agave_ml'], $unit ) ),
+                'flavour' => $amounts['extra'],
             ),
             'salt_rim'   => $this->salt_rim( $drinks, $wet_rim ),
             'abv'        => $abv,
             'preset'     => $preset_key,
+            'preset_label' => $preset['label'] ?? ucfirst( $preset_key ),
+            'flavour'    => $meta,
             'suffix'     => $this->unit_suffix( $unit ),
         );
     }
+
 }

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -21,67 +21,113 @@ class MM_Plugin {
             'nonce'    => wp_create_nonce( 'mm_nonce' ),
         ) );
     }
+    protected function sanitize_bool( $value, $fallback = true ) {
+        if ( is_bool( $value ) ) {
+            return $value;
+        }
+        if ( '' === $value || null === $value ) {
+            return $fallback;
+        }
+        return in_array( strtolower( (string) $value ), array( '1', 'true', 'yes', 'on' ), true );
+    }
+
     public function render_shortcode( $atts = array() ) {
         wp_enqueue_style( 'mm-frontend' );
         wp_enqueue_style( 'mm-print' );
         wp_enqueue_script( 'mm-frontend' );
+
         $default_unit   = get_option( 'mm_unit', 'ml' );
         $default_preset = get_option( 'mm_default_preset', 'classic' );
         $max_drinks     = (int) get_option( 'mm_max_drinks', 25 );
-        $show_abv       = (bool) get_option( 'mm_show_abv', 1 );
-        $presets = $this->calc->list_presets();
+        $admin_show_abv = (bool) get_option( 'mm_show_abv', 1 );
+        $presets        = $this->calc->list_presets();
+        $flavours       = $this->calc->list_flavours();
+        $allowed_units  = array( 'ml', 'oz', 'shot', 'nip' );
+        $allowed_modes  = array( 'drinks', 'pitcher' );
+
+        $atts = shortcode_atts(
+            array(
+                'preset'   => $default_preset,
+                'unit'     => $default_unit,
+                'flavour'  => 'none',
+                'drinks'   => 1,
+                'show_abv' => $admin_show_abv ? 'true' : 'false',
+                'mode'     => 'drinks',
+                'title'    => __( 'Margarita Measurements', 'margarita-measurements' ),
+            ),
+            $atts,
+            'margarita_measurements'
+        );
+
+        $preset = sanitize_key( $atts['preset'] );
+        $preset = isset( $presets[ $preset ] ) ? $preset : ( isset( $presets[ $default_preset ] ) ? $default_preset : 'classic' );
+        $unit   = sanitize_key( $atts['unit'] );
+        $unit   = in_array( $unit, $allowed_units, true ) ? $unit : ( in_array( $default_unit, $allowed_units, true ) ? $default_unit : 'ml' );
+        $mode   = sanitize_key( $atts['mode'] );
+        $mode   = in_array( $mode, $allowed_modes, true ) ? $mode : 'drinks';
+        $drinks = min( max( 1, absint( $atts['drinks'] ) ), max( 1, $max_drinks ) );
+        $show_abv = $this->sanitize_bool( $atts['show_abv'], $admin_show_abv );
+        $flavour  = $this->calc->normalise_flavour_key( $atts['flavour'] );
+        $title    = sanitize_text_field( $atts['title'] );
+        $title    = '' === $title ? __( 'Margarita Measurements', 'margarita-measurements' ) : $title;
+        $instance = wp_unique_id( 'mm-' );
         ob_start(); ?>
         <div class="mm-wrap">
-            <form class="mm-form" aria-describedby="mm-help" novalidate>
+            <form class="mm-form" aria-describedby="<?php echo esc_attr( $instance ); ?>-help" novalidate>
+                <h2 class="mm-title"><?php echo esc_html( $title ); ?></h2>
                 <div class="mm-row">
-                    <label for="mm_preset"><?php echo esc_html__( 'Preset', 'margarita-measurements' ); ?></label>
-                    <select id="mm_preset" name="preset">
+                    <label for="<?php echo esc_attr( $instance ); ?>-preset"><?php echo esc_html__( 'Preset', 'margarita-measurements' ); ?></label>
+                    <select id="<?php echo esc_attr( $instance ); ?>-preset" name="preset">
                         <?php foreach ( $presets as $key => $p ): ?>
-                            <option value="<?php echo esc_attr( $key ); ?>" <?php selected( $key, $default_preset ); ?>>
+                            <option value="<?php echo esc_attr( $key ); ?>" <?php selected( $key, $preset ); ?>>
                                 <?php echo esc_html( $p['label'] ?? ucfirst( $key ) ); ?>
                             </option>
                         <?php endforeach; ?>
                     </select>
                 </div>
                 <div class="mm-row">
-                    <label for="mm_drinks"><?php echo esc_html__( 'Drinks', 'margarita-measurements' ); ?></label>
-                    <input id="mm_drinks" name="drinks" type="number" min="1" max="<?php echo esc_attr( $max_drinks ); ?>" value="1" />
-                </div>
-                <div class="mm-row">
-                    <label for="mm_mode"><?php esc_html_e( 'Mode', 'margarita-measurements' ); ?></label>
-                    <select id="mm_mode" name="mode">
-                        <option value="drinks"><?php esc_html_e( 'Per drink count', 'margarita-measurements' ); ?></option>
-                        <option value="pitcher"><?php esc_html_e( 'Pitcher (total ml)', 'margarita-measurements' ); ?></option>
+                    <label for="<?php echo esc_attr( $instance ); ?>-flavour"><?php echo esc_html__( 'Flavour', 'margarita-measurements' ); ?></label>
+                    <select id="<?php echo esc_attr( $instance ); ?>-flavour" name="flavour">
+                        <?php foreach ( $flavours as $key => $f ): ?>
+                            <option value="<?php echo esc_attr( $key ); ?>" <?php selected( $key, $flavour ); ?>><?php echo esc_html( $f['label'] ); ?></option>
+                        <?php endforeach; ?>
                     </select>
                 </div>
-                <div class="mm-row mm-pitcher-row" style="display:none;">
-                    <label for="mm_pitcher_ml"><?php esc_html_e( 'Pitcher size (ml)', 'margarita-measurements' ); ?></label>
-                    <input id="mm_pitcher_ml" name="pitcher_ml" type="number" min="100" max="5000" step="50" value="1000" />
+                <div class="mm-row">
+                    <label for="<?php echo esc_attr( $instance ); ?>-drinks"><?php echo esc_html__( 'Drinks', 'margarita-measurements' ); ?></label>
+                    <input id="<?php echo esc_attr( $instance ); ?>-drinks" name="drinks" type="number" min="1" max="<?php echo esc_attr( $max_drinks ); ?>" value="<?php echo esc_attr( $drinks ); ?>" />
                 </div>
                 <div class="mm-row">
-                    <label>
-                        <input type="checkbox" name="wet_rim" value="1" checked />
-                        <?php esc_html_e( 'Wet rim (more salt)', 'margarita-measurements' ); ?>
-                    </label>
+                    <label for="<?php echo esc_attr( $instance ); ?>-mode"><?php esc_html_e( 'Mode', 'margarita-measurements' ); ?></label>
+                    <select id="<?php echo esc_attr( $instance ); ?>-mode" name="mode">
+                        <option value="drinks" <?php selected( 'drinks', $mode ); ?>><?php esc_html_e( 'Per drink count', 'margarita-measurements' ); ?></option>
+                        <option value="pitcher" <?php selected( 'pitcher', $mode ); ?>><?php esc_html_e( 'Pitcher (total ml)', 'margarita-measurements' ); ?></option>
+                    </select>
+                </div>
+                <div class="mm-row mm-pitcher-row"<?php echo 'pitcher' === $mode ? '' : ' style="display:none;"'; ?>>
+                    <label for="<?php echo esc_attr( $instance ); ?>-pitcher"><?php esc_html_e( 'Pitcher size (ml)', 'margarita-measurements' ); ?></label>
+                    <input id="<?php echo esc_attr( $instance ); ?>-pitcher" name="pitcher_ml" type="number" min="100" max="5000" step="50" value="1000" />
+                </div>
+                <div class="mm-row">
+                    <label><input type="checkbox" name="wet_rim" value="1" checked /> <?php esc_html_e( 'Wet rim (more salt)', 'margarita-measurements' ); ?></label>
                 </div>
                 <fieldset class="mm-fieldset">
                     <legend><?php echo esc_html__( 'Units', 'margarita-measurements' ); ?></legend>
                     <?php foreach ( array( 'ml' => 'ml', 'oz' => 'oz', 'shot' => 'Shot', 'nip' => 'Nip' ) as $val => $label ) : ?>
-                        <label class="mm-radio">
-                            <input type="radio" name="unit" value="<?php echo esc_attr( $val ); ?>" <?php checked( $val, $default_unit ); ?> />
-                            <span><?php echo esc_html( $label ); ?></span>
-                        </label>
+                        <label class="mm-radio"><input type="radio" name="unit" value="<?php echo esc_attr( $val ); ?>" <?php checked( $val, $unit ); ?> /> <span><?php echo esc_html( $label ); ?></span></label>
                     <?php endforeach; ?>
                 </fieldset>
                 <input type="hidden" name="action" value="mm_calculate" />
+                <input type="hidden" name="show_abv" value="<?php echo esc_attr( $show_abv ? '1' : '0' ); ?>" />
                 <input type="hidden" name="nonce" value="<?php echo esc_attr( wp_create_nonce( 'mm_nonce' ) ); ?>" />
                 <button type="submit" class="mm-btn"><?php echo esc_html__( 'Calculate', 'margarita-measurements' ); ?></button>
             </form>
-            <div id="mm-results" class="mm-results" aria-live="polite"></div>
-            <p id="mm-help" class="mm-help"><?php echo esc_html__( 'Tip: switch units or try presets like Tommy’s or Frozen.', 'margarita-measurements' ); ?></p>
+            <div class="mm-results" aria-live="polite"></div>
+            <p id="<?php echo esc_attr( $instance ); ?>-help" class="mm-help"><?php echo esc_html__( 'Tip: switch units, add a flavour, or try presets like Tommy’s or Frozen.', 'margarita-measurements' ); ?></p>
         </div>
         <?php return ob_get_clean();
     }
+
     public function register_block() {
         register_block_type( __DIR__ . '/../block', array(
             'render_callback' => function( $attributes, $content ) {

--- a/includes/class-rest.php
+++ b/includes/class-rest.php
@@ -14,6 +14,7 @@ class MM_REST {
                 'mode'       => array( 'sanitize_callback' => 'sanitize_key' ),
                 'unit'       => array( 'sanitize_callback' => 'sanitize_text_field' ),
                 'wet_rim'    => array( 'sanitize_callback' => 'rest_sanitize_boolean' ),
+                'flavour'    => array( 'sanitize_callback' => 'sanitize_key' ),
             ),
             'callback' => array( $this, 'calc' ),
         ) );
@@ -26,11 +27,16 @@ class MM_REST {
             'drinks'     => min( max( 1, (int) $request->get_param( 'drinks' ) ), $max ),
             'pitcher_ml' => min( 5000, max( 100, (float) ( $request->get_param( 'pitcher_ml' ) ?: 1000 ) ) ),
             'unit'       => $request->get_param( 'unit' ) ?: get_option( 'mm_unit', 'ml' ),
+            'flavour'    => $request->get_param( 'flavour' ) ?: 'none',
             'wet_rim'    => null === $request->get_param( 'wet_rim' ) ? true : (bool) $request->get_param( 'wet_rim' ),
         );
         $calc            = MM_Plugin::instance()->calc;
         $allowed_presets = array_keys( $calc->list_presets() );
+        $allowed_units   = array( 'ml', 'oz', 'shot', 'nip' );
         $args['preset']  = in_array( $args['preset'], $allowed_presets, true ) ? $args['preset'] : 'classic';
+        $args['unit']    = in_array( $args['unit'], $allowed_units, true ) ? $args['unit'] : get_option( 'mm_unit', 'ml' );
+        $args['flavour'] = $calc->normalise_flavour_key( $args['flavour'] );
+        $mode            = in_array( $mode, array( 'drinks', 'pitcher' ), true ) ? $mode : 'drinks';
         $data            = 'pitcher' === $mode ? $calc->pitcher( $args ) : $calc->batch( $args );
         foreach ( $data['quantities'] as &$v ) {
             if ( is_array( $v ) && isset( $v['display'] ) ) { $v['display'] = round( $v['display'], 2 ); }

--- a/margarita-measurements.php
+++ b/margarita-measurements.php
@@ -3,7 +3,7 @@
  * Plugin Name: Margarita Measurements
  * Plugin URI: #
  * Description: Calculate perfect margarita ratios with presets, units, and ABV estimate. Shortcode: [margarita_measurements]. Also provides a Gutenberg block.
- * Version: 2.3.0
+ * Version: 2.4.0
  * Author: Bryan Chetcuti (https://github.com/bchetcuti/margaritaWP)
  * Text Domain: margarita-measurements
  * Requires at least: 5.8
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'MM_VERSION', '2.3.0' );
+define( 'MM_VERSION', '2.4.0' );
 define( 'MM_PLUGIN_FILE', __FILE__ );
 define( 'MM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'MM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: Bryan Chetcuti
 Requires at least: 5.8
 Tested up to: 7.0
-Stable tag: 2.3.0
+Stable tag: 2.4.0
 Requires PHP: 8.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -13,6 +13,10 @@ Calculate perfect margarita ratios with presets, unit switching, and ABV estimat
 - Presets: Classic, Tommy’s, Frozen, Skinny
 - Units: ml, oz, shot, nip
 - ABV estimate (toggle)
+- Flavour variations: none, spicy, mango, watermelon, strawberry, coconut, virgin
+- Shortcode attributes for preset, unit, flavour, drinks, show_abv, mode, and title
+- Inline clipboard copy confirmation
+- Themeable CSS variables with dark mode support
 - Gutenberg block + shortcode `[margarita_measurements]`
 - REST endpoint: `/wp-json/margarita/v1/calculate?preset=classic&drinks=4&unit=ml`
 - AJAX form (no page reload), accessible, i18n-ready
@@ -36,6 +40,12 @@ Yes, in **Settings → Margarita Measurements**.
 Yes. The shortcode works anywhere.
 
 == Changelog ==
+= 2.4.0 =
+- Feature: Flavour variations for spicy, mango, watermelon, strawberry, coconut, and virgin margaritas.
+- Feature: Shortcode attributes for per-instance preset, unit, flavour, drinks, show_abv, mode, and title overrides.
+- Enhancement: Copy action now uses inline “✓ Copied!” feedback with a clipboard fallback and no alert.
+- Enhancement: Frontend styles now use CSS custom properties and support prefers-color-scheme dark mode.
+
 = 2.3.0 =
 - WordPress 7.0 compatibility confirmed; bumped Tested up to.
 - Fixed MM_VERSION constant mismatch (was 2.1.0, now 2.3.0).

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,3 +1,6 @@
 <?php
 // Minimal bootstrap placeholder for CI.
+if ( ! function_exists( '__' ) ) { function __( $text, $domain = null ) { return $text; } }
+if ( ! function_exists( 'sanitize_key' ) ) { function sanitize_key( $key ) { return strtolower( preg_replace( '/[^a-z0-9_\-]/', '', (string) $key ) ); } }
+if ( ! function_exists( 'get_option' ) ) { function get_option( $key, $default = false ) { return $default; } }
 require_once dirname(__DIR__) . '/includes/class-calculator.php';

--- a/tests/test-calculator.php
+++ b/tests/test-calculator.php
@@ -9,4 +9,27 @@ final class CalculatorTest extends TestCase {
         $this->assertArrayHasKey('quantities', $out);
         $this->assertGreaterThan(0, $out['quantities']['tequila']['ml']);
     }
+
+    public function test_mango_adds_nectar_and_dilutes_abv() {
+        $c = new MM_Calculator();
+        $plain = $c->batch([ 'preset' => 'classic', 'drinks' => 1, 'unit' => 'ml' ]);
+        $mango = $c->batch([ 'preset' => 'classic', 'drinks' => 1, 'unit' => 'ml', 'flavour' => 'mango' ]);
+        $this->assertEquals('mango', $mango['flavour']['key']);
+        $this->assertEquals(30.0, $mango['quantities']['flavour']['ml']);
+        $this->assertLessThan($plain['abv'], $mango['abv']);
+    }
+
+    public function test_virgin_removes_alcohol() {
+        $c = new MM_Calculator();
+        $out = $c->batch([ 'preset' => 'classic', 'drinks' => 1, 'unit' => 'ml', 'flavour' => 'virgin' ]);
+        $this->assertEquals(0.0, $out['quantities']['tequila']['ml']);
+        $this->assertEquals(0.0, $out['quantities']['triple']['ml']);
+        $this->assertEquals(0, $out['abv']);
+        $this->assertTrue($out['flavour']['no_alcohol']);
+    }
+
+    public function test_invalid_flavour_falls_back_to_none() {
+        $c = new MM_Calculator();
+        $this->assertEquals('none', $c->normalise_flavour_key('bad-flavour'));
+    }
 }


### PR DESCRIPTION
### Motivation
- Provide a small, backwards-compatible v2.4.0 slice that adds flavour variations to recipes without changing presets, and surfaces per-instance shortcode overrides. 
- Replace alert-based clipboard feedback with a friendly inline confirmation and clipboard fallback to improve UX. 
- Make the frontend themeable and dark-mode friendly using CSS custom properties without a visual rewrite. 
- Keep existing behaviour and security patterns (sanitisation, clamping) intact while adding these features.

### Description
- Added a flavour registry and helpers in `MM_Calculator` (`list_flavours()`, `get_flavour()`, `normalise_flavour_key()`) and applied flavour adjustments in `batch()` and `pitcher()` so flavours (none, spicy, mango, watermelon, strawberry, coconut, virgin) modify quantities and ABV appropriately. 
- Extended the shortcode renderer in `includes/class-plugin.php` to use `shortcode_atts()` and per-instance sanitised attributes for `preset`, `unit`, `flavour`, `drinks`, `show_abv`, `mode`, and `title`, and added a flavour dropdown to the UI while preserving admin defaults. 
- Updated AJAX and REST handlers to accept and sanitise `flavour`, validate `unit` and `mode` against allowlists, clamp `drinks`, and suppress ABV when `show_abv` is disabled or a no-alcohol flavour is selected. 
- Reworked frontend logic in `assets/js/frontend.js` to render flavour-aware ingredient rows, produce a human-readable `copyText()` payload, implement `writeClipboard()` with `navigator.clipboard.writeText()` + `document.execCommand('copy')` fallback, and show inline `✓ Copied!` feedback for 2 seconds; print output updated to include flavour and labels. 
- Introduced CSS custom properties on `.mm-wrap` and added `prefers-color-scheme: dark` rules in `assets/css/frontend.css` to theme the calculator surface, controls, buttons and results while keeping the visual changes minimal. 
- Updated documentation (`readme.txt` / plugin header) and added unit-style tests for flavour behaviour in `tests/test-calculator.php` to cover mango dilution, virgin alcohol removal, and invalid flavour fallback.

### Testing
- Ran PHP lint across PHP files with `php -l` and confirmed there were no syntax errors. 
- Validated frontend JS syntax with `node -c assets/js/frontend.js` and it passed. 
- Executed a small PHP verification script (`php -r 'require "tests/bootstrap.php"; ...'`) that exercises `MM_Calculator::batch()` for `mango`, `watermelon`, `coconut` and `virgin` flavours and it returned the expected results (checks passed). 
- Added PHPUnit tests in `tests/test-calculator.php` but `phpunit` was not available in this environment so full test runner and `phpcs` style checks could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2dd2135f6c832bbbb948c8fbbe5eec)