### PR TITLE
Add Party Planning mode

### DIFF
--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -34,7 +34,11 @@
         if (d.flavour && d.flavour.key !== 'none') {
             lines.push('Flavour: ' + d.flavour.label);
         }
-        lines.push(d.mode === 'pitcher' ? 'Pitcher: ' + d.pitcher_ml + ' ml total' : 'Drinks: ' + d.drinks);
+        if (d.mode === 'party') {
+            lines.push('Party: ' + d.guests + ' guests, ' + d.total_margaritas + ' margaritas');
+        } else {
+            lines.push(d.mode === 'pitcher' ? 'Pitcher: ' + d.pitcher_ml + ' ml total' : 'Drinks: ' + d.drinks);
+        }
         lines.push('Ingredients:');
         ingredientRows(d).forEach(function(row){ lines.push('- ' + row[0] + ': ' + row[1]); });
         if (typeof d.abv !== 'undefined') {
@@ -69,7 +73,9 @@
     }
 
     $(document).on('change', 'select[name="mode"]', function(){
-        $(this).closest('.mm-form').find('.mm-pitcher-row').toggle( $(this).val() === 'pitcher' );
+        var mode = $(this).val();
+        $(this).closest('.mm-form').find('.mm-pitcher-row').toggle(mode === 'pitcher');
+        $(this).closest('.mm-form').find('.mm-party-fields').toggle(mode === 'party');
     });
 
     $(document).on('submit', '.mm-form', function(e){
@@ -86,7 +92,7 @@
         data.action = 'mm_calculate';
         data.nonce  = MM_Ajax.nonce;
 
-        if (data.mode === 'pitcher') {
+        if (data.mode === 'pitcher' || data.mode === 'party') {
             delete data.drinks;
         }
 
@@ -97,9 +103,11 @@
             }
             var d = resp.data;
             $results.data('mm-result', d);
-            var title = d.mode === 'pitcher'
-                ? 'Pitcher (' + esc(d.pitcher_ml) + ' ml total) — ' + esc(d.preset_label || titleCase(d.preset))
-                : 'Batch for ' + esc(d.drinks) + ' drink(s) — ' + esc(d.preset_label || titleCase(d.preset));
+            var title = d.mode === 'party'
+                ? 'Party plan for ' + esc(d.guests) + ' guest(s) — ' + esc(d.total_margaritas) + ' margaritas'
+                : (d.mode === 'pitcher'
+                    ? 'Pitcher (' + esc(d.pitcher_ml) + ' ml total) — ' + esc(d.preset_label || titleCase(d.preset))
+                    : 'Batch for ' + esc(d.drinks) + ' drink(s) — ' + esc(d.preset_label || titleCase(d.preset)));
             if (d.flavour && d.flavour.key !== 'none') {
                 title += ' · ' + esc(d.flavour.label);
             }
@@ -121,6 +129,27 @@
             }
             if (d.salt_rim) {
                 html += '<p>🧂 <strong>Salt rim:</strong> ~' + esc(d.salt_rim.grams) + 'g (' + esc(d.salt_rim.tsps) + ' tsp) — ' + esc(d.salt_rim.wet_dry) + ' rim</p>';
+            }
+            if (d.mode === 'party') {
+                html += '<h4>Shopping list</h4>';
+                ['spirits', 'mixers'].forEach(function(group){
+                    if (!d.shopping_list || !d.shopping_list[group] || !d.shopping_list[group].length) { return; }
+                    html += '<h5>' + esc(titleCase(group)) + '</h5><ul>';
+                    d.shopping_list[group].forEach(function(item){
+                        html += '<li><strong>' + esc(item.label) + ':</strong> ' + esc(item.display) + ' ' + esc(d.suffix) + ' (' + esc(item.bottles) + ' × ' + esc(item.bottle_ml) + ' ml)</li>';
+                    });
+                    html += '</ul>';
+                });
+                if (d.garnish_extras) {
+                    html += '<h4>Garnish & extras</h4><ul>';
+                    html += '<li>Lime wedges: ' + esc(d.garnish_extras.lime_wedges) + ' (~' + esc(d.garnish_extras.limes) + ' limes)</li>';
+                    html += '<li>Ice: ~' + esc(d.garnish_extras.ice_kg) + ' kg</li>';
+                    html += '<li>Rim salt: ~' + esc(d.garnish_extras.salt.grams) + 'g</li>';
+                    html += '</ul>';
+                }
+                if (d.responsible_drinking) {
+                    html += '<p class="mm-note"><strong>Responsible drinking:</strong> ' + esc(d.responsible_drinking.note) + ' Estimated total standard drinks: ' + esc(d.responsible_drinking.estimated_standard_drinks) + '.</p>';
+                }
             }
             html += '<div class="mm-actions">';
             html += '<button class="mm-print mm-btn-secondary" type="button">Print</button>';

--- a/includes/class-ajax.php
+++ b/includes/class-ajax.php
@@ -18,6 +18,10 @@ class MM_Ajax {
             'unit'       => sanitize_key( wp_unslash( $_POST['unit'] ?? get_option( 'mm_unit', 'ml' ) ) ),
             'flavour'    => sanitize_key( wp_unslash( $_POST['flavour'] ?? 'none' ) ),
             'wet_rim'    => ! empty( $_POST['wet_rim'] ),
+            'guests'     => min( 500, max( 1, absint( wp_unslash( $_POST['guests'] ?? 10 ) ) ) ),
+            'drinks_per_person' => min( 12, max( 0.1, (float) wp_unslash( $_POST['drinks_per_person'] ?? 2 ) ) ),
+            'event_duration' => min( 24, max( 0.5, (float) wp_unslash( $_POST['event_duration'] ?? 2 ) ) ),
+            'standard_drink_region' => sanitize_key( wp_unslash( $_POST['standard_drink_region'] ?? get_option( 'mm_standard_drink_region', 'AU' ) ) ),
         );
         $calc            = MM_Plugin::instance()->calc;
         $allowed_presets = array_keys( $calc->list_presets() );
@@ -25,12 +29,26 @@ class MM_Ajax {
         $args['preset']  = in_array( $args['preset'], $allowed_presets, true ) ? $args['preset'] : 'classic';
         $args['unit']    = in_array( $args['unit'], $allowed_units, true ) ? $args['unit'] : get_option( 'mm_unit', 'ml' );
         $args['flavour'] = $calc->normalise_flavour_key( $args['flavour'] );
-        $mode            = in_array( $mode, array( 'drinks', 'pitcher' ), true ) ? $mode : 'drinks';
-        $data            = 'pitcher' === $mode ? $calc->pitcher( $args ) : $calc->batch( $args );
+        $mode            = in_array( $mode, array( 'drinks', 'pitcher', 'party' ), true ) ? $mode : 'drinks';
+        if ( 'party' === $mode ) {
+            $args['standard_drink_region'] = $calc->normalise_standard_drink_region( $args['standard_drink_region'] );
+            $data = $calc->party( $args );
+        } else {
+            $data = 'pitcher' === $mode ? $calc->pitcher( $args ) : $calc->batch( $args );
+        }
         foreach ( $data['quantities'] as &$v ) {
             if ( is_array( $v ) && isset( $v['display'] ) ) { $v['display'] = round( $v['display'], 2 ); }
         }
         unset( $v );
+        if ( ! empty( $data['shopping_list'] ) ) {
+            foreach ( $data['shopping_list'] as &$group ) {
+                foreach ( $group as &$item ) {
+                    if ( isset( $item['display'] ) ) { $item['display'] = round( $item['display'], 2 ); }
+                }
+                unset( $item );
+            }
+            unset( $group );
+        }
         $data['abv'] = round( $data['abv'], 1 );
         if ( empty( $_POST['show_abv'] ) || ! empty( $data['flavour']['no_alcohol'] ) ) {
             unset( $data['abv'] );

--- a/includes/class-calculator.php
+++ b/includes/class-calculator.php
@@ -178,7 +178,7 @@ class MM_Calculator {
     }
 
     public function normalise_standard_drink_region( $region ) {
-        $region  = strtoupper( sanitize_key( $region ) );
+        $region  = strtoupper( sanitize_key( strtolower( (string) $region ) ) );
         $regions = $this->standard_drink_regions();
         return isset( $regions[ $region ] ) ? $region : 'AU';
     }

--- a/includes/class-calculator.php
+++ b/includes/class-calculator.php
@@ -168,6 +168,103 @@ class MM_Calculator {
         );
     }
 
+
+    public function standard_drink_regions() {
+        return array(
+            'AU' => array( 'label' => __( 'Australia (10g)', 'margarita-measurements' ), 'grams' => 10.0 ),
+            'US' => array( 'label' => __( 'United States (14g)', 'margarita-measurements' ), 'grams' => 14.0 ),
+            'UK' => array( 'label' => __( 'United Kingdom unit (8g)', 'margarita-measurements' ), 'grams' => 8.0 ),
+        );
+    }
+
+    public function normalise_standard_drink_region( $region ) {
+        $region  = strtoupper( sanitize_key( $region ) );
+        $regions = $this->standard_drink_regions();
+        return isset( $regions[ $region ] ) ? $region : 'AU';
+    }
+
+    public function bottle_sizes() {
+        $defaults = array(
+            'tequila' => 700.0,
+            'triple'  => 700.0,
+            'citrus'  => 1000.0,
+            'agave'   => 350.0,
+            'mixer'   => 1000.0,
+        );
+        $saved = get_option( 'mm_bottle_sizes', array() );
+        if ( is_array( $saved ) ) {
+            foreach ( $defaults as $key => $default ) {
+                if ( isset( $saved[ $key ] ) ) {
+                    $defaults[ $key ] = min( 5000.0, max( 50.0, (float) $saved[ $key ] ) );
+                }
+            }
+        }
+        return $defaults;
+    }
+
+    protected function bottle_count( $ml, $bottle_ml ) {
+        $bottle_ml = max( 1.0, (float) $bottle_ml );
+        return (int) ceil( max( 0.0, (float) $ml ) / $bottle_ml );
+    }
+
+    protected function party_item( $label, $ml, $unit, $bottle_ml, $type ) {
+        return array(
+            'label'     => $label,
+            'type'      => $type,
+            'ml'        => $ml,
+            'display'   => $this->ml_to_unit( $ml, $unit ),
+            'bottle_ml' => $bottle_ml,
+            'bottles'   => $this->bottle_count( $ml, $bottle_ml ),
+        );
+    }
+
+    public function party( $args ) {
+        $guests       = min( 500, max( 1, (int) ( $args['guests'] ?? 10 ) ) );
+        $per_person   = min( 12.0, max( 0.1, (float) ( $args['drinks_per_person'] ?? 2 ) ) );
+        $duration     = min( 24.0, max( 0.5, (float) ( $args['event_duration'] ?? 2 ) ) );
+        $total_drinks = (int) ceil( $guests * $per_person );
+        $unit         = $args['unit'] ?? 'ml';
+        $result       = $this->batch( array_merge( $args, array( 'drinks' => $total_drinks ) ) );
+        $presets      = $this->list_presets();
+        $preset       = $presets[ $result['preset'] ] ?? $this->presets['classic'];
+        $sizes        = $this->bottle_sizes();
+        $region_key   = $this->normalise_standard_drink_region( $args['standard_drink_region'] ?? get_option( 'mm_standard_drink_region', 'AU' ) );
+        $regions      = $this->standard_drink_regions();
+        $std_grams    = $regions[ $region_key ]['grams'];
+        $tequila_ml   = $result['quantities']['tequila']['ml'];
+        $triple_ml    = $result['quantities']['triple']['ml'];
+        $triple_abv   = ( $result['quantities']['total_ml'] > 0 && $triple_ml > 0 ) ? ( $preset['triple_abv'] ?? 0.40 ) : 0.0;
+        $alc_grams    = ( ( $tequila_ml * 0.40 ) + ( $triple_ml * $triple_abv ) ) * 0.789;
+        $shopping     = array(
+            'spirits' => array(),
+            'mixers'  => array(),
+        );
+        if ( $tequila_ml > 0 ) { $shopping['spirits'][] = $this->party_item( $result['quantities']['tequila']['label'] ?? __( 'Tequila', 'margarita-measurements' ), $tequila_ml, $unit, $sizes['tequila'], 'spirit' ); }
+        if ( $triple_ml > 0 ) { $shopping['spirits'][] = $this->party_item( __( 'Triple sec', 'margarita-measurements' ), $triple_ml, $unit, $sizes['triple'], 'spirit' ); }
+        $shopping['mixers'][] = $this->party_item( __( 'Citrus juice', 'margarita-measurements' ), $result['quantities']['citrus']['ml'], $unit, $sizes['citrus'], 'mixer' );
+        if ( $result['quantities']['agave']['ml'] > 0 ) { $shopping['mixers'][] = $this->party_item( __( 'Agave syrup', 'margarita-measurements' ), $result['quantities']['agave']['ml'], $unit, $sizes['agave'], 'mixer' ); }
+        if ( ! empty( $result['quantities']['flavour'] ) && $result['quantities']['flavour']['ml'] > 0 ) { $shopping['mixers'][] = $this->party_item( $result['quantities']['flavour']['label'], $result['quantities']['flavour']['ml'], $unit, $sizes['mixer'], 'mixer' ); }
+        $result['mode'] = 'party';
+        $result['guests'] = $guests;
+        $result['drinks_per_person'] = $per_person;
+        $result['event_duration'] = $duration;
+        $result['total_margaritas'] = $total_drinks;
+        $result['shopping_list'] = $shopping;
+        $result['garnish_extras'] = array(
+            'lime_wedges' => $total_drinks,
+            'limes'       => (int) ceil( $total_drinks / 8 ),
+            'salt'        => $this->salt_rim( $total_drinks, ! empty( $args['wet_rim'] ) ),
+            'ice_kg'      => round( $total_drinks * (float) ( $preset['ice_factor'] ?? 1.0 ) * 0.18, 1 ),
+        );
+        $result['responsible_drinking'] = array(
+            'region' => $region_key,
+            'standard_drink_grams' => $std_grams,
+            'estimated_standard_drinks' => round( $std_grams > 0 ? $alc_grams / $std_grams : 0, 1 ),
+            'note' => sprintf( __( 'Plan water, food, transport and alcohol-free options. Estimates use %1$s standard drinks at %2$sg alcohol each; Australia defaults to 10g.', 'margarita-measurements' ), $region_key, $std_grams ),
+        );
+        return $result;
+    }
+
     public function batch( $args ) {
         $preset_key  = isset( $args['preset'] ) ? $args['preset'] : 'classic';
         $drinks      = max( 1, (int) ( $args['drinks'] ?? 1 ) );

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -40,6 +40,7 @@ class MM_Plugin {
         $default_preset = get_option( 'mm_default_preset', 'classic' );
         $max_drinks     = (int) get_option( 'mm_max_drinks', 25 );
         $admin_show_abv = (bool) get_option( 'mm_show_abv', 1 );
+        $default_standard_drink_region = $this->calc->normalise_standard_drink_region( get_option( 'mm_standard_drink_region', 'AU' ) );
         $presets        = $this->calc->list_presets();
         $flavours       = $this->calc->list_flavours();
         $allowed_units  = array( 'ml', 'oz', 'shot', 'nip' );
@@ -113,7 +114,7 @@ class MM_Plugin {
                     <div class="mm-row"><label for="<?php echo esc_attr( $instance ); ?>-guests"><?php esc_html_e( 'Guests', 'margarita-measurements' ); ?></label><input id="<?php echo esc_attr( $instance ); ?>-guests" name="guests" type="number" min="1" max="500" value="10" /></div>
                     <div class="mm-row"><label for="<?php echo esc_attr( $instance ); ?>-drinks-person"><?php esc_html_e( 'Drinks per person', 'margarita-measurements' ); ?></label><input id="<?php echo esc_attr( $instance ); ?>-drinks-person" name="drinks_per_person" type="number" min="0.1" max="12" step="0.1" value="2" /></div>
                     <div class="mm-row"><label for="<?php echo esc_attr( $instance ); ?>-duration"><?php esc_html_e( 'Event duration (hours)', 'margarita-measurements' ); ?></label><input id="<?php echo esc_attr( $instance ); ?>-duration" name="event_duration" type="number" min="0.5" max="24" step="0.5" value="2" /></div>
-                    <div class="mm-row"><label for="<?php echo esc_attr( $instance ); ?>-standard-region"><?php esc_html_e( 'Standard drink', 'margarita-measurements' ); ?></label><select id="<?php echo esc_attr( $instance ); ?>-standard-region" name="standard_drink_region"><option value="AU">Australia (10g)</option><option value="US">United States (14g)</option><option value="UK">United Kingdom (8g)</option></select></div>
+                    <div class="mm-row"><label for="<?php echo esc_attr( $instance ); ?>-standard-region"><?php esc_html_e( 'Standard drink', 'margarita-measurements' ); ?></label><select id="<?php echo esc_attr( $instance ); ?>-standard-region" name="standard_drink_region"><?php foreach ( $this->calc->standard_drink_regions() as $region => $details ) : ?><option value="<?php echo esc_attr( $region ); ?>" <?php selected( $default_standard_drink_region, $region ); ?>><?php echo esc_html( $details['label'] ); ?></option><?php endforeach; ?></select></div>
                 </div>
                 <div class="mm-row">
                     <label><input type="checkbox" name="wet_rim" value="1" checked /> <?php esc_html_e( 'Wet rim (more salt)', 'margarita-measurements' ); ?></label>

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -43,7 +43,7 @@ class MM_Plugin {
         $presets        = $this->calc->list_presets();
         $flavours       = $this->calc->list_flavours();
         $allowed_units  = array( 'ml', 'oz', 'shot', 'nip' );
-        $allowed_modes  = array( 'drinks', 'pitcher' );
+        $allowed_modes  = array( 'drinks', 'pitcher', 'party' );
 
         $atts = shortcode_atts(
             array(
@@ -102,11 +102,18 @@ class MM_Plugin {
                     <select id="<?php echo esc_attr( $instance ); ?>-mode" name="mode">
                         <option value="drinks" <?php selected( 'drinks', $mode ); ?>><?php esc_html_e( 'Per drink count', 'margarita-measurements' ); ?></option>
                         <option value="pitcher" <?php selected( 'pitcher', $mode ); ?>><?php esc_html_e( 'Pitcher (total ml)', 'margarita-measurements' ); ?></option>
+                        <option value="party" <?php selected( 'party', $mode ); ?>><?php esc_html_e( 'Party Planning', 'margarita-measurements' ); ?></option>
                     </select>
                 </div>
                 <div class="mm-row mm-pitcher-row"<?php echo 'pitcher' === $mode ? '' : ' style="display:none;"'; ?>>
                     <label for="<?php echo esc_attr( $instance ); ?>-pitcher"><?php esc_html_e( 'Pitcher size (ml)', 'margarita-measurements' ); ?></label>
                     <input id="<?php echo esc_attr( $instance ); ?>-pitcher" name="pitcher_ml" type="number" min="100" max="5000" step="50" value="1000" />
+                </div>
+                <div class="mm-party-fields"<?php echo 'party' === $mode ? '' : ' style="display:none;"'; ?>>
+                    <div class="mm-row"><label for="<?php echo esc_attr( $instance ); ?>-guests"><?php esc_html_e( 'Guests', 'margarita-measurements' ); ?></label><input id="<?php echo esc_attr( $instance ); ?>-guests" name="guests" type="number" min="1" max="500" value="10" /></div>
+                    <div class="mm-row"><label for="<?php echo esc_attr( $instance ); ?>-drinks-person"><?php esc_html_e( 'Drinks per person', 'margarita-measurements' ); ?></label><input id="<?php echo esc_attr( $instance ); ?>-drinks-person" name="drinks_per_person" type="number" min="0.1" max="12" step="0.1" value="2" /></div>
+                    <div class="mm-row"><label for="<?php echo esc_attr( $instance ); ?>-duration"><?php esc_html_e( 'Event duration (hours)', 'margarita-measurements' ); ?></label><input id="<?php echo esc_attr( $instance ); ?>-duration" name="event_duration" type="number" min="0.5" max="24" step="0.5" value="2" /></div>
+                    <div class="mm-row"><label for="<?php echo esc_attr( $instance ); ?>-standard-region"><?php esc_html_e( 'Standard drink', 'margarita-measurements' ); ?></label><select id="<?php echo esc_attr( $instance ); ?>-standard-region" name="standard_drink_region"><option value="AU">Australia (10g)</option><option value="US">United States (14g)</option><option value="UK">United Kingdom (8g)</option></select></div>
                 </div>
                 <div class="mm-row">
                     <label><input type="checkbox" name="wet_rim" value="1" checked /> <?php esc_html_e( 'Wet rim (more salt)', 'margarita-measurements' ); ?></label>

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -34,7 +34,7 @@ class MM_Settings {
     public function sanitize_bool( $val ) { return $val ? 1 : 0; }
     public function sanitize_standard_drink_region( $val ) {
         $allowed = array( 'AU', 'US', 'UK' );
-        $val = strtoupper( sanitize_key( $val ) );
+        $val = strtoupper( sanitize_key( strtolower( (string) $val ) ) );
         return in_array( $val, $allowed, true ) ? $val : 'AU';
     }
     public function sanitize_bottle_sizes( $value ) {

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -23,6 +23,8 @@ class MM_Settings {
         register_setting( 'mm_settings', 'mm_default_preset', array( 'type' => 'string', 'sanitize_callback' => 'sanitize_text_field', 'default' => 'classic' ) );
         register_setting( 'mm_settings', 'mm_max_drinks', array( 'type' => 'integer', 'sanitize_callback' => 'absint', 'default' => 25 ) );
         register_setting( 'mm_settings', 'mm_show_abv', array( 'type' => 'boolean', 'sanitize_callback' => array( $this, 'sanitize_bool' ), 'default' => 1 ) );
+        register_setting( 'mm_settings', 'mm_standard_drink_region', array( 'type' => 'string', 'sanitize_callback' => array( $this, 'sanitize_standard_drink_region' ), 'default' => 'AU' ) );
+        register_setting( 'mm_settings', 'mm_bottle_sizes', array( 'type' => 'array', 'sanitize_callback' => array( $this, 'sanitize_bottle_sizes' ), 'default' => array() ) );
         register_setting( 'mm_custom_presets_settings', 'mm_custom_presets', array( 'type' => 'array', 'sanitize_callback' => array( $this, 'sanitize_custom_presets' ), 'default' => array() ) );
     }
     public function sanitize_unit( $val ) {
@@ -30,6 +32,20 @@ class MM_Settings {
         return in_array( $val, $allowed, true ) ? $val : 'ml';
     }
     public function sanitize_bool( $val ) { return $val ? 1 : 0; }
+    public function sanitize_standard_drink_region( $val ) {
+        $allowed = array( 'AU', 'US', 'UK' );
+        $val = strtoupper( sanitize_key( $val ) );
+        return in_array( $val, $allowed, true ) ? $val : 'AU';
+    }
+    public function sanitize_bottle_sizes( $value ) {
+        $defaults = array( 'tequila' => 700, 'triple' => 700, 'citrus' => 1000, 'agave' => 350, 'mixer' => 1000 );
+        $clean = array();
+        $value = is_array( $value ) ? $value : array();
+        foreach ( $defaults as $key => $default ) {
+            $clean[ $key ] = min( 5000, max( 50, (float) ( $value[ $key ] ?? $default ) ) );
+        }
+        return $clean;
+    }
     public function sanitize_custom_presets( $value ) {
         $existing = get_option( 'mm_custom_presets', array() );
         $presets  = is_array( $existing ) ? $existing : array();
@@ -100,6 +116,19 @@ class MM_Settings {
                     <tr>
                         <th scope="row"><?php esc_html_e( 'Show ABV', 'margarita-measurements' ); ?></th>
                         <td><input type="checkbox" name="mm_show_abv" value="1" <?php checked( get_option('mm_show_abv', 1 ), 1 ); ?> /></td>
+                    </tr>
+                    <tr>
+                        <th scope="row"><label for="mm_standard_drink_region"><?php esc_html_e( 'Standard drink default', 'margarita-measurements' ); ?></label></th>
+                        <td><select id="mm_standard_drink_region" name="mm_standard_drink_region"><?php foreach ( array( 'AU' => 'Australia (10g)', 'US' => 'United States (14g)', 'UK' => 'United Kingdom (8g)' ) as $region => $label ) : ?><option value="<?php echo esc_attr( $region ); ?>" <?php selected( get_option( 'mm_standard_drink_region', 'AU' ), $region ); ?>><?php echo esc_html( $label ); ?></option><?php endforeach; ?></select></td>
+                    </tr>
+                    <?php $mm_bottle_sizes = MM_Plugin::instance()->calc->bottle_sizes(); ?>
+                    <tr>
+                        <th scope="row"><?php esc_html_e( 'Party bottle sizes (ml)', 'margarita-measurements' ); ?></th>
+                        <td class="mm-bottle-size-settings">
+                            <?php foreach ( array( 'tequila' => 'Tequila', 'triple' => 'Triple sec', 'citrus' => 'Citrus juice', 'agave' => 'Agave syrup', 'mixer' => 'Flavour mixers' ) as $key => $label ) : ?>
+                                <label><?php echo esc_html( $label ); ?> <input type="number" name="mm_bottle_sizes[<?php echo esc_attr( $key ); ?>]" min="50" max="5000" step="50" value="<?php echo esc_attr( $mm_bottle_sizes[ $key ] ); ?>" /></label><br />
+                            <?php endforeach; ?>
+                        </td>
                     </tr>
                 </table>
                 <?php submit_button(); ?>

--- a/tests/test-calculator.php
+++ b/tests/test-calculator.php
@@ -32,6 +32,13 @@ final class CalculatorTest extends TestCase {
         $c = new MM_Calculator();
         $this->assertEquals('none', $c->normalise_flavour_key('bad-flavour'));
     }
+
+    public function test_standard_drink_region_normalises_configured_defaults() {
+        $c = new MM_Calculator();
+        $this->assertEquals('US', $c->normalise_standard_drink_region('US'));
+        $this->assertEquals('UK', $c->normalise_standard_drink_region('uk'));
+        $this->assertEquals('AU', $c->normalise_standard_drink_region('invalid'));
+    }
     public function test_party_planning_outputs_shopping_list_and_au_standard_drinks() {
         $c = new MM_Calculator();
         $out = $c->party([ 'preset' => 'classic', 'guests' => 10, 'drinks_per_person' => 2, 'event_duration' => 3, 'unit' => 'ml', 'wet_rim' => true ]);

--- a/tests/test-calculator.php
+++ b/tests/test-calculator.php
@@ -32,4 +32,17 @@ final class CalculatorTest extends TestCase {
         $c = new MM_Calculator();
         $this->assertEquals('none', $c->normalise_flavour_key('bad-flavour'));
     }
+    public function test_party_planning_outputs_shopping_list_and_au_standard_drinks() {
+        $c = new MM_Calculator();
+        $out = $c->party([ 'preset' => 'classic', 'guests' => 10, 'drinks_per_person' => 2, 'event_duration' => 3, 'unit' => 'ml', 'wet_rim' => true ]);
+        $this->assertEquals('party', $out['mode']);
+        $this->assertEquals(20, $out['total_margaritas']);
+        $this->assertEquals(10, $out['guests']);
+        $this->assertEquals(2.0, $out['drinks_per_person']);
+        $this->assertNotEmpty($out['shopping_list']['spirits']);
+        $this->assertNotEmpty($out['shopping_list']['mixers']);
+        $this->assertEquals(10.0, $out['responsible_drinking']['standard_drink_grams']);
+        $this->assertEquals('AU', $out['responsible_drinking']['region']);
+        $this->assertGreaterThan(0, $out['garnish_extras']['limes']);
+    }
 }


### PR DESCRIPTION
### Motivation
- Implement a Party Planning mode that converts guest counts and event parameters into total margaritas and actionable shopping/garnish/responsible-drinking output. 
- Provide configurable bottle sizes and standard-drink region handling (defaulting to AU 10g) so shopping estimates and responsible-drinking notes are useful for real events.

### Description
- Added new calculator helpers and party logic in `includes/class-calculator.php`, including `standard_drink_regions`, `normalise_standard_drink_region`, `bottle_sizes`, `bottle_count`, `party_item`, and the main `party` method that returns `total_margaritas`, `shopping_list`, `garnish_extras`, and `responsible_drinking` metadata. 
- Extended AJAX handling in `includes/class-ajax.php` to accept `guests`, `drinks_per_person`, `event_duration`, and `standard_drink_region`, dispatch the `party` mode, and round shopping-list display values for frontend consumption. 
- Updated the shortcode/form UI in `includes/class-plugin.php` to include `party` in `allowed_modes` and to render input fields for `Guests`, `Drinks per person`, `Event duration`, and `Standard drink` selection. 
- Updated frontend JavaScript in `assets/js/frontend.js` to toggle party fields, omit the `drinks` field for party submissions, and render the shopping list, bottle counts, garnish/extras, and a responsible-drinking note; and added settings in `includes/class-settings.php` to register `mm_standard_drink_region` and `mm_bottle_sizes` plus sanitizers and UI controls to adjust defaults.

### Testing
- Ran `git diff --check` to validate diffs and style checks which passed. 
- Ran PHP syntax checks `php -l` against `includes/class-calculator.php`, `includes/class-plugin.php`, `includes/class-settings.php`, `includes/class-ajax.php`, and `tests/test-calculator.php`, all of which reported no syntax errors. 
- Ran `node --check assets/js/frontend.js` to validate the frontend script which succeeded. 
- Executed a runtime smoke test invoking `MM_Calculator->party(...)` via `php -r` which returned the expected `party` output (verified totals, shopping lists and AU standard-drink default). 
- Attempted to run `phpunit -c tests/phpunit.xml` but `phpunit` was not available in the environment so the full test suite could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2dd43d8d10832b9560b6582d393a0c)