### PR TITLE
Add Gutenberg block attributes, InspectorControls, and presets REST route

### DIFF
--- a/block/block.json
+++ b/block/block.json
@@ -16,5 +16,31 @@
   "style": "file:./style.css",
   "supports": {
     "html": false
+  },
+  "attributes": {
+    "preset": {
+      "type": "string",
+      "default": "classic"
+    },
+    "unit": {
+      "type": "string",
+      "default": "ml"
+    },
+    "flavour": {
+      "type": "string",
+      "default": "none"
+    },
+    "mode": {
+      "type": "string",
+      "default": "drinks"
+    },
+    "showAbv": {
+      "type": "boolean",
+      "default": true
+    },
+    "title": {
+      "type": "string",
+      "default": "Margarita Measurements"
+    }
   }
 }

--- a/block/editor.js
+++ b/block/editor.js
@@ -1,10 +1,101 @@
 ( function() {
     const el = wp.element.createElement;
     const registerBlockType = wp.blocks.registerBlockType;
+    const InspectorControls = wp.blockEditor.InspectorControls;
+    const PanelBody = wp.components.PanelBody;
+    const SelectControl = wp.components.SelectControl;
+    const ToggleControl = wp.components.ToggleControl;
+    const TextControl = wp.components.TextControl;
+    const useEffect = wp.element.useEffect;
+    const useState = wp.element.useState;
+    const apiFetch = wp.apiFetch;
+
+    const unitOptions = [
+        { label: 'ml', value: 'ml' },
+        { label: 'oz', value: 'oz' },
+        { label: 'Shot', value: 'shot' },
+        { label: 'Nip', value: 'nip' },
+    ];
+
+    const flavourOptions = [
+        { label: 'None', value: 'none' },
+        { label: 'Spicy', value: 'spicy' },
+        { label: 'Mango', value: 'mango' },
+        { label: 'Watermelon', value: 'watermelon' },
+        { label: 'Strawberry', value: 'strawberry' },
+        { label: 'Coconut', value: 'coconut' },
+        { label: 'Virgin', value: 'virgin' },
+    ];
+
+    const modeOptions = [
+        { label: 'Per drink count', value: 'drinks' },
+        { label: 'Pitcher (total ml)', value: 'pitcher' },
+        { label: 'Party Planning', value: 'party' },
+    ];
 
     registerBlockType('margarita/measurements', {
-        edit: function() {
-            return el('div', { className: 'mm-block-editor' }, 'Margarita Measurements will render on the front-end.');
+        edit: function( props ) {
+            const attributes = props.attributes;
+            const setAttributes = props.setAttributes;
+            const [ presetOptions, setPresetOptions ] = useState( [ { label: 'Classic', value: 'classic' } ] );
+
+            useEffect( function() {
+                apiFetch( { path: '/margarita/v1/presets' } ).then( function( presets ) {
+                    if ( Array.isArray( presets ) && presets.length ) {
+                        setPresetOptions( presets.map( function( preset ) {
+                            return { label: preset.label, value: preset.key };
+                        } ) );
+                    }
+                } ).catch( function() {} );
+            }, [] );
+
+            return el(
+                wp.element.Fragment,
+                {},
+                el(
+                    InspectorControls,
+                    {},
+                    el(
+                        PanelBody,
+                        { title: 'Margarita settings', initialOpen: true },
+                        el( SelectControl, {
+                            label: 'Preset',
+                            value: attributes.preset,
+                            options: presetOptions,
+                            onChange: function( preset ) { setAttributes( { preset: preset } ); },
+                        } ),
+                        el( SelectControl, {
+                            label: 'Unit',
+                            value: attributes.unit,
+                            options: unitOptions,
+                            onChange: function( unit ) { setAttributes( { unit: unit } ); },
+                        } ),
+                        el( SelectControl, {
+                            label: 'Flavour',
+                            value: attributes.flavour,
+                            options: flavourOptions,
+                            onChange: function( flavour ) { setAttributes( { flavour: flavour } ); },
+                        } ),
+                        el( SelectControl, {
+                            label: 'Mode',
+                            value: attributes.mode,
+                            options: modeOptions,
+                            onChange: function( mode ) { setAttributes( { mode: mode } ); },
+                        } ),
+                        el( ToggleControl, {
+                            label: 'Show ABV',
+                            checked: attributes.showAbv,
+                            onChange: function( showAbv ) { setAttributes( { showAbv: showAbv } ); },
+                        } ),
+                        el( TextControl, {
+                            label: 'Title',
+                            value: attributes.title,
+                            onChange: function( title ) { setAttributes( { title: title } ); },
+                        } )
+                    )
+                ),
+                el('div', { className: 'mm-block-editor' }, attributes.title || 'Margarita Measurements will render on the front-end.')
+            );
         },
         save: function() { return null; } // Server-side render
     });

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -31,18 +31,12 @@ class MM_Plugin {
         return in_array( strtolower( (string) $value ), array( '1', 'true', 'yes', 'on' ), true );
     }
 
-    public function render_shortcode( $atts = array() ) {
-        wp_enqueue_style( 'mm-frontend' );
-        wp_enqueue_style( 'mm-print' );
-        wp_enqueue_script( 'mm-frontend' );
-
+    public function sanitize_render_atts( $atts = array() ) {
         $default_unit   = get_option( 'mm_unit', 'ml' );
         $default_preset = get_option( 'mm_default_preset', 'classic' );
         $max_drinks     = (int) get_option( 'mm_max_drinks', 25 );
         $admin_show_abv = (bool) get_option( 'mm_show_abv', 1 );
-        $default_standard_drink_region = $this->calc->normalise_standard_drink_region( get_option( 'mm_standard_drink_region', 'AU' ) );
         $presets        = $this->calc->list_presets();
-        $flavours       = $this->calc->list_flavours();
         $allowed_units  = array( 'ml', 'oz', 'shot', 'nip' );
         $allowed_modes  = array( 'drinks', 'pitcher', 'party' );
 
@@ -67,10 +61,50 @@ class MM_Plugin {
         $mode   = sanitize_key( $atts['mode'] );
         $mode   = in_array( $mode, $allowed_modes, true ) ? $mode : 'drinks';
         $drinks = min( max( 1, absint( $atts['drinks'] ) ), max( 1, $max_drinks ) );
-        $show_abv = $this->sanitize_bool( $atts['show_abv'], $admin_show_abv );
-        $flavour  = $this->calc->normalise_flavour_key( $atts['flavour'] );
-        $title    = sanitize_text_field( $atts['title'] );
-        $title    = '' === $title ? __( 'Margarita Measurements', 'margarita-measurements' ) : $title;
+        $title  = sanitize_text_field( $atts['title'] );
+
+        return array(
+            'preset'   => $preset,
+            'unit'     => $unit,
+            'flavour'  => $this->calc->normalise_flavour_key( $atts['flavour'] ),
+            'drinks'   => $drinks,
+            'show_abv' => $this->sanitize_bool( $atts['show_abv'], $admin_show_abv ),
+            'mode'     => $mode,
+            'title'    => '' === $title ? __( 'Margarita Measurements', 'margarita-measurements' ) : $title,
+        );
+    }
+
+    protected function block_attributes_to_shortcode_atts( $attributes ) {
+        $atts = array();
+        foreach ( array( 'preset', 'unit', 'flavour', 'mode', 'title' ) as $key ) {
+            if ( isset( $attributes[ $key ] ) ) {
+                $atts[ $key ] = $attributes[ $key ];
+            }
+        }
+        if ( array_key_exists( 'showAbv', $attributes ) ) {
+            $atts['show_abv'] = $attributes['showAbv'] ? 'true' : 'false';
+        }
+        return $atts;
+    }
+
+    public function render_shortcode( $atts = array() ) {
+        wp_enqueue_style( 'mm-frontend' );
+        wp_enqueue_style( 'mm-print' );
+        wp_enqueue_script( 'mm-frontend' );
+
+        $max_drinks = (int) get_option( 'mm_max_drinks', 25 );
+        $default_standard_drink_region = $this->calc->normalise_standard_drink_region( get_option( 'mm_standard_drink_region', 'AU' ) );
+        $presets   = $this->calc->list_presets();
+        $flavours  = $this->calc->list_flavours();
+        $atts      = $this->sanitize_render_atts( $atts );
+
+        $preset   = $atts['preset'];
+        $unit     = $atts['unit'];
+        $mode     = $atts['mode'];
+        $drinks   = $atts['drinks'];
+        $show_abv = $atts['show_abv'];
+        $flavour  = $atts['flavour'];
+        $title    = $atts['title'];
         $instance = wp_unique_id( 'mm-' );
         ob_start(); ?>
         <div class="mm-wrap">
@@ -139,7 +173,7 @@ class MM_Plugin {
     public function register_block() {
         register_block_type( __DIR__ . '/../block', array(
             'render_callback' => function( $attributes, $content ) {
-                return $this->render_shortcode();
+                return $this->render_shortcode( $this->block_attributes_to_shortcode_atts( is_array( $attributes ) ? $attributes : array() ) );
             },
         ) );
     }

--- a/includes/class-rest.php
+++ b/includes/class-rest.php
@@ -4,6 +4,12 @@ class MM_REST {
     public static function instance() { if ( null === self::$instance ) { self::$instance = new self(); } return self::$instance; }
     private function __construct() { add_action( 'rest_api_init', array( $this, 'routes' ) ); }
     public function routes() {
+
+        register_rest_route( 'margarita/v1', '/presets', array(
+            'methods'  => 'GET',
+            'permission_callback' => '__return_true',
+            'callback' => array( $this, 'presets' ),
+        ) );
         register_rest_route( 'margarita/v1', '/calculate', array(
             'methods'  => 'GET',
             'permission_callback' => '__return_true',
@@ -18,6 +24,25 @@ class MM_REST {
             ),
             'callback' => array( $this, 'calc' ),
         ) );
+    }
+
+    public function presets( WP_REST_Request $request ) {
+        $presets = MM_Plugin::instance()->calc->list_presets();
+        $data    = array();
+
+        foreach ( $presets as $key => $preset ) {
+            $key = sanitize_key( $key );
+            if ( '' === $key ) {
+                continue;
+            }
+            $data[] = array(
+                'key'   => $key,
+                'label' => sanitize_text_field( $preset['label'] ?? ucfirst( $key ) ),
+                'note'  => sanitize_text_field( $preset['note'] ?? '' ),
+            );
+        }
+
+        return rest_ensure_response( $data );
     }
     public function calc( WP_REST_Request $request ) {
         $max  = (int) get_option( 'mm_max_drinks', 25 );


### PR DESCRIPTION
### Motivation
- Provide Gutenberg block users with the same configurable options as the shortcode by adding block attributes for preset, unit, flavour, mode, ABV visibility and title.
- Surface available presets to the block editor so editors can choose presets without hard-coding options in the client.
- Ensure block rendering uses the same sanitized rendering path as the shortcode to avoid duplication and keep server-side output consistent.

### Description
- Add block metadata attributes for `preset`, `unit`, `flavour`, `mode`, `showAbv`, and `title` in `block/block.json` so the block can persist and use these values.
- Implement editor `InspectorControls` in `block/editor.js` with `SelectControl`/`ToggleControl`/`TextControl`, fetch presets from `/margarita/v1/presets`, and expose UI for preset/unit/flavour/mode/ABV/title selection.
- Add `sanitize_render_atts()` and `block_attributes_to_shortcode_atts()` in `includes/class-plugin.php` and route block rendering through `render_shortcode()` using the sanitized mapping so block attributes go through the same sanitisation and rendering path as the shortcode.
- Add a public REST endpoint at `/margarita/v1/presets` in `includes/class-rest.php` that returns sanitized preset `key`, `label`, and `note` for the editor to consume.

### Testing
- Ran PHP syntax checks with `php -l includes/class-plugin.php`, `php -l includes/class-rest.php`, `php -l margarita-measurements.php`, and `php -l includes/class-calculator.php`, all of which reported no syntax errors.
- Ran `git diff --check` which produced no whitespace/patch issues.
- Attempted `phpunit -c tests/phpunit.xml` but `phpunit` is not installed in the environment so unit tests were not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2dda0ded94832b8c69a1dff02d16ee)