### PR TITLE
v3.0 — Nutrition & standard-drinks estimator, ABV customiser, compact widget, and WP.org assets

### DIFF
--- a/assets-wporg/README.md
+++ b/assets-wporg/README.md
@@ -1,0 +1,32 @@
+# WordPress.org asset plan
+
+This directory is for WordPress.org listing assets. Existing PNG assets may be replaced before release if updated artwork is produced; do not load these assets remotely from the plugin frontend.
+
+## Banner
+
+- File: `banner-1544x500.png` or `banner-1544x500.jpg`
+- Size: 1544 × 500 px
+- Concept: clean cream/warm white background, lime wedge illustration, plugin name, and tagline: “Perfect ratios. Every time.”
+
+## Icon
+
+- File: `icon-256x256.png`
+- Size: 256 × 256 px
+- Concept: stylised margarita glass silhouette, geometric, two-colour, readable at small sizes.
+
+## Screenshot storyboard
+
+Recommended files:
+
+1. `screenshot-1.png` — clean full calculator on a light theme.
+2. `screenshot-2.png` — result card for 4 drinks using Tommy’s.
+3. `screenshot-3.png` — flavour selector showing implemented variants.
+4. `screenshot-4.png` — pitcher or batch output.
+5. `screenshot-5.png` — print recipe card output.
+6. `screenshot-6.png` — custom preset builder in settings.
+7. `screenshot-7.png` — Gutenberg block/sidebar view.
+8. `screenshot-8.png` — compact `[margarita_widget]` inside a recipe post.
+9. `screenshot-9.png` — nutrition and standard drinks panel expanded.
+10. `screenshot-10.png` — mobile responsive view.
+
+Do not add screenshots for unimplemented visitor account, sharing, analytics, or data-storage features unless those features are implemented in a later release.

--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -54,3 +54,20 @@
     .mm-btn-secondary:hover { color: #111827; }
 }
 @media (max-width:640px){ .mm-grid-3 { grid-template-columns: 1fr; } .mm-row { flex-direction:column; align-items:flex-start; } .mm-row > label { width:auto; } }
+.mm-advanced summary,
+.mm-nutrition summary { cursor: pointer; font-weight: 600; }
+.mm-nutrition { border-top: 1px solid var(--mm-border); padding-top: .5rem; }
+.mm-nutrition-grid { display:grid; grid-template-columns: repeat(3, minmax(0,1fr)); gap:.75rem; margin-top:.5rem; }
+.mm-nutrition-grid > div { border:1px solid var(--mm-border); border-radius:.375rem; padding:.5rem; background: var(--mm-bg); }
+.mm-metric-label { display:block; color: var(--mm-text-muted); font-size:.82em; margin-bottom:.15rem; }
+.mm-widget { max-width: 320px; padding:.75rem; font-family: inherit; }
+.mm-widget .mm-row { display:block; }
+.mm-widget .mm-row > label { display:block; width:auto; margin-bottom:.2rem; }
+.mm-widget .mm-fieldset { margin-top:.5rem; }
+.mm-widget .mm-radio { display:inline-block; margin-bottom:.25rem; }
+.mm-widget__title { margin:0 0 .75rem; font-size:1.1em; }
+.mm-widget__result .mm-card { background: transparent; }
+.mm-widget--align-right { float:right; margin:0 0 1rem 1rem; }
+.mm-widget--align-left { float:left; margin:0 1rem 1rem 0; }
+.mm-widget--align-center { margin-inline:auto; }
+@media (max-width:640px){ .mm-nutrition-grid { grid-template-columns:1fr; } .mm-widget, .mm-widget--align-right, .mm-widget--align-left, .mm-widget--align-center { float:none; width:100%; max-width:none; margin-inline:0; } }

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -28,6 +28,26 @@
         return rows;
     }
 
+
+    function nutritionDetails(d) {
+        if (!d.nutrition) { return ''; }
+        var n = d.nutrition;
+        var html = '<details class="mm-details mm-nutrition">';
+        html += '<summary>Nutrition &amp; standard drinks</summary>';
+        html += '<div class="mm-nutrition-grid">';
+        html += '<div><span class="mm-metric-label">Estimated calories</span><strong>~' + esc(n.calories_per_drink) + ' kcal</strong></div>';
+        html += '<div><span class="mm-metric-label">Alcohol</span><strong>' + esc(n.alcohol_grams_per_drink) + 'g</strong></div>';
+        html += '<div><span class="mm-metric-label">Standard drinks</span><strong>' + esc(n.standard_drinks_per_drink) + ' ' + esc(n.region) + ' standard drinks</strong></div>';
+        html += '<div><span class="mm-metric-label">Region</span><strong>' + esc(n.region_label) + '</strong></div>';
+        if (typeof d.abv !== 'undefined' && !(d.flavour && d.flavour.no_alcohol)) {
+            html += '<div><span class="mm-metric-label">Estimated ABV</span><strong>' + esc(d.abv) + '%</strong></div>';
+        }
+        html += '</div>';
+        html += '<p class="mm-help">' + esc(n.help || 'Approximate values for recipe planning only.') + ' ' + esc(n.calorie_note || '') + '</p>';
+        html += '</details>';
+        return html;
+    }
+
     function copyText(d) {
         var lines = ['Margarita Recipe'];
         lines.push('Preset: ' + (d.preset_label || titleCase(d.preset)));
@@ -130,6 +150,7 @@
             if (d.salt_rim) {
                 html += '<p>🧂 <strong>Salt rim:</strong> ~' + esc(d.salt_rim.grams) + 'g (' + esc(d.salt_rim.tsps) + ' tsp) — ' + esc(d.salt_rim.wet_dry) + ' rim</p>';
             }
+            html += nutritionDetails(d);
             if (d.mode === 'party') {
                 html += '<h4>Shopping list</h4>';
                 ['spirits', 'mixers'].forEach(function(group){

--- a/includes/class-ajax.php
+++ b/includes/class-ajax.php
@@ -21,7 +21,10 @@ class MM_Ajax {
             'guests'     => min( 500, max( 1, absint( wp_unslash( $_POST['guests'] ?? 10 ) ) ) ),
             'drinks_per_person' => min( 12, max( 0.1, (float) wp_unslash( $_POST['drinks_per_person'] ?? 2 ) ) ),
             'event_duration' => min( 24, max( 0.5, (float) wp_unslash( $_POST['event_duration'] ?? 2 ) ) ),
-            'standard_drink_region' => sanitize_key( wp_unslash( $_POST['standard_drink_region'] ?? get_option( 'mm_standard_drink_region', 'AU' ) ) ),
+            'standard_drink_region' => sanitize_key( wp_unslash( $_POST['standard_drink_region'] ?? $_POST['standard_region'] ?? get_option( 'mm_standard_drink_region', 'AU' ) ) ),
+            'standard_region' => sanitize_key( wp_unslash( $_POST['standard_region'] ?? $_POST['standard_drink_region'] ?? get_option( 'mm_standard_drink_region', 'AU' ) ) ),
+            'tequila_abv' => wp_unslash( $_POST['tequila_abv'] ?? 40 ),
+            'triple_sec_abv' => wp_unslash( $_POST['triple_sec_abv'] ?? 40 ),
         );
         $calc            = MM_Plugin::instance()->calc;
         $allowed_presets = array_keys( $calc->list_presets() );
@@ -29,6 +32,10 @@ class MM_Ajax {
         $args['preset']  = in_array( $args['preset'], $allowed_presets, true ) ? $args['preset'] : 'classic';
         $args['unit']    = in_array( $args['unit'], $allowed_units, true ) ? $args['unit'] : get_option( 'mm_unit', 'ml' );
         $args['flavour'] = $calc->normalise_flavour_key( $args['flavour'] );
+        $args['standard_region'] = $calc->normalise_standard_drink_region( $args['standard_region'] );
+        $args['standard_drink_region'] = $calc->normalise_standard_drink_region( $args['standard_drink_region'] );
+        $args['tequila_abv'] = $calc->sanitize_tequila_abv( $args['tequila_abv'] );
+        $args['triple_sec_abv'] = $calc->sanitize_triple_sec_abv( $args['triple_sec_abv'] );
         $mode            = in_array( $mode, array( 'drinks', 'pitcher', 'party' ), true ) ? $mode : 'drinks';
         if ( 'party' === $mode ) {
             $args['standard_drink_region'] = $calc->normalise_standard_drink_region( $args['standard_drink_region'] );
@@ -52,6 +59,9 @@ class MM_Ajax {
         $data['abv'] = round( $data['abv'], 1 );
         if ( empty( $_POST['show_abv'] ) || ! empty( $data['flavour']['no_alcohol'] ) ) {
             unset( $data['abv'] );
+        }
+        if ( empty( $_POST['show_nutrition'] ) ) {
+            unset( $data['nutrition'] );
         }
         wp_send_json_success( $data );
     }

--- a/includes/class-calculator.php
+++ b/includes/class-calculator.php
@@ -93,8 +93,62 @@ class MM_Calculator {
         }
     }
 
-    public function abv_estimate( $tequila_ml, $triple_ml, $total_ml, $triple_abv = 0.40 ) {
-        $alc_ml = ( $tequila_ml * 0.40 ) + ( $triple_ml * $triple_abv );
+    public function sanitize_tequila_abv( $value ) {
+        if ( ! is_numeric( $value ) ) {
+            return 40.0;
+        }
+        return min( 55.0, max( 35.0, (float) $value ) );
+    }
+
+    public function sanitize_triple_sec_abv( $value ) {
+        if ( ! is_numeric( $value ) ) {
+            return 40.0;
+        }
+        return min( 45.0, max( 15.0, (float) $value ) );
+    }
+
+    public function normalise_abv_overrides( $args = array(), $preset = array() ) {
+        $preset_triple_abv = isset( $preset['triple_abv'] ) ? ( (float) $preset['triple_abv'] * 100 ) : 40.0;
+        return array(
+            'tequila_abv'    => $this->sanitize_tequila_abv( $args['tequila_abv'] ?? 40.0 ),
+            'triple_sec_abv' => $this->sanitize_triple_sec_abv( $args['triple_sec_abv'] ?? $preset_triple_abv ),
+        );
+    }
+
+    public function calculate_alcohol_ml( $quantities, $abv_overrides = array() ) {
+        $tequila_abv    = $this->sanitize_tequila_abv( $abv_overrides['tequila_abv'] ?? 40.0 ) / 100;
+        $triple_sec_abv = $this->sanitize_triple_sec_abv( $abv_overrides['triple_sec_abv'] ?? 40.0 ) / 100;
+        $tequila_ml     = isset( $quantities['tequila']['ml'] ) ? (float) $quantities['tequila']['ml'] : 0.0;
+        $triple_ml      = isset( $quantities['triple']['ml'] ) ? (float) $quantities['triple']['ml'] : 0.0;
+        return ( $tequila_ml * $tequila_abv ) + ( $triple_ml * $triple_sec_abv );
+    }
+
+    public function calculate_alcohol_grams( $alcohol_ml ) {
+        return max( 0.0, (float) $alcohol_ml ) * 0.789;
+    }
+
+    public function calculate_standard_drinks( $alcohol_grams, $region ) {
+        $regions = $this->standard_drink_regions();
+        $region  = $this->normalise_standard_drink_region( $region );
+        $grams   = $regions[ $region ]['grams'];
+        return $grams > 0 ? (float) $alcohol_grams / $grams : 0.0;
+    }
+
+    public function calculate_calories( $quantities, $abv_overrides = array() ) {
+        $alcohol_grams   = $this->calculate_alcohol_grams( $this->calculate_alcohol_ml( $quantities, $abv_overrides ) );
+        $alcohol_kcal    = $alcohol_grams * 7;
+        $sweetener_ml    = isset( $quantities['agave']['ml'] ) ? (float) $quantities['agave']['ml'] : 0.0;
+        $sweetener_kcal  = $sweetener_ml * 3.1;
+        return array(
+            'total_kcal'     => $alcohol_kcal + $sweetener_kcal,
+            'alcohol_kcal'   => $alcohol_kcal,
+            'sweetener_kcal' => $sweetener_kcal,
+            'includes'       => $sweetener_ml > 0 ? __( 'Includes alcohol and sweetener estimate.', 'margarita-measurements' ) : __( 'Alcohol calories only.', 'margarita-measurements' ),
+        );
+    }
+
+    public function abv_estimate( $tequila_ml, $triple_ml, $total_ml, $triple_abv = 0.40, $tequila_abv = 0.40 ) {
+        $alc_ml = ( $tequila_ml * $tequila_abv ) + ( $triple_ml * $triple_abv );
         if ( $total_ml <= 0 ) {
             return 0;
         }
@@ -172,8 +226,8 @@ class MM_Calculator {
     public function standard_drink_regions() {
         return array(
             'AU' => array( 'label' => __( 'Australia (10g)', 'margarita-measurements' ), 'grams' => 10.0 ),
+            'UK' => array( 'label' => __( 'United Kingdom (8g)', 'margarita-measurements' ), 'grams' => 8.0 ),
             'US' => array( 'label' => __( 'United States (14g)', 'margarita-measurements' ), 'grams' => 14.0 ),
-            'UK' => array( 'label' => __( 'United Kingdom unit (8g)', 'margarita-measurements' ), 'grams' => 8.0 ),
         );
     }
 
@@ -181,6 +235,31 @@ class MM_Calculator {
         $region  = strtoupper( sanitize_key( strtolower( (string) $region ) ) );
         $regions = $this->standard_drink_regions();
         return isset( $regions[ $region ] ) ? $region : 'AU';
+    }
+
+    protected function add_nutrition( $result, $args, $abv_overrides ) {
+        $region          = $this->normalise_standard_drink_region( $args['standard_region'] ?? $args['standard_drink_region'] ?? 'AU' );
+        $regions         = $this->standard_drink_regions();
+        $alcohol_ml      = $this->calculate_alcohol_ml( $result['quantities'], $abv_overrides );
+        $alcohol_grams   = $this->calculate_alcohol_grams( $alcohol_ml );
+        $standard_drinks = $this->calculate_standard_drinks( $alcohol_grams, $region );
+        $calories        = $this->calculate_calories( $result['quantities'], $abv_overrides );
+        $divisor         = isset( $result['drinks'] ) ? max( 1, (int) $result['drinks'] ) : 1;
+        $result['nutrition'] = array(
+            'region'                => $region,
+            'region_label'          => $regions[ $region ]['label'],
+            'standard_drink_grams'  => $regions[ $region ]['grams'],
+            'alcohol_ml'            => round( $alcohol_ml, 2 ),
+            'alcohol_grams'         => round( $alcohol_grams, 2 ),
+            'alcohol_grams_per_drink' => round( $alcohol_grams / $divisor, 2 ),
+            'standard_drinks'       => round( $standard_drinks, 2 ),
+            'standard_drinks_per_drink' => round( $standard_drinks / $divisor, 2 ),
+            'calories'              => round( $calories['total_kcal'] ),
+            'calories_per_drink'    => round( $calories['total_kcal'] / $divisor ),
+            'calorie_note'          => $calories['includes'],
+            'help'                  => __( 'Approximate values for recipe planning only.', 'margarita-measurements' ),
+        );
+        return $result;
     }
 
     public function bottle_sizes() {
@@ -233,8 +312,8 @@ class MM_Calculator {
         $std_grams    = $regions[ $region_key ]['grams'];
         $tequila_ml   = $result['quantities']['tequila']['ml'];
         $triple_ml    = $result['quantities']['triple']['ml'];
-        $triple_abv   = ( $result['quantities']['total_ml'] > 0 && $triple_ml > 0 ) ? ( $preset['triple_abv'] ?? 0.40 ) : 0.0;
-        $alc_grams    = ( ( $tequila_ml * 0.40 ) + ( $triple_ml * $triple_abv ) ) * 0.789;
+        $abv_overrides = $this->normalise_abv_overrides( $args, $preset );
+        $alc_grams    = $this->calculate_alcohol_grams( $this->calculate_alcohol_ml( $result['quantities'], $abv_overrides ) );
         $shopping     = array(
             'spirits' => array(),
             'mixers'  => array(),
@@ -262,7 +341,7 @@ class MM_Calculator {
             'estimated_standard_drinks' => round( $std_grams > 0 ? $alc_grams / $std_grams : 0, 1 ),
             'note' => sprintf( __( 'Plan water, food, transport and alcohol-free options. Estimates use %1$s standard drinks at %2$sg alcohol each; Australia defaults to 10g.', 'margarita-measurements' ), $region_key, $std_grams ),
         );
-        return $result;
+        return $this->add_nutrition( $result, $args, $abv_overrides );
     }
 
     public function batch( $args ) {
@@ -284,13 +363,14 @@ class MM_Calculator {
         $amounts     = $this->apply_flavour( $amounts, $flavour_key, $drinks );
         $ice_mul     = $preset['ice_factor'];
         $total_ml    = $amounts['tequila_ml'] + $amounts['citrus_ml'] + $amounts['triple_ml'] + $amounts['agave_ml'] + $amounts['extra_ml'];
-        $meta        = $this->flavour_meta( $flavour_key );
-        $abv         = $meta['no_alcohol'] ? 0 : $this->abv_estimate( $amounts['tequila_ml'], $amounts['triple_ml'], $total_ml, $preset['triple_abv'] ?? 0.40 );
+        $meta          = $this->flavour_meta( $flavour_key );
+        $abv_overrides = $this->normalise_abv_overrides( $args, $preset );
+        $abv           = $meta['no_alcohol'] ? 0 : $this->abv_estimate( $amounts['tequila_ml'], $amounts['triple_ml'], $total_ml, $abv_overrides['triple_sec_abv'] / 100, $abv_overrides['tequila_abv'] / 100 );
         if ( ! empty( $amounts['extra'] ) ) {
             $amounts['extra']['display'] = $this->ml_to_unit( $amounts['extra']['ml'], $unit );
         }
 
-        return array(
+        $result = array(
             'mode'       => 'drinks',
             'drinks'     => $drinks,
             'unit'       => $unit,
@@ -309,7 +389,9 @@ class MM_Calculator {
             'preset_label' => $preset['label'] ?? ucfirst( $preset_key ),
             'flavour'    => $meta,
             'suffix'     => $this->unit_suffix( $unit ),
+            'abv_overrides' => $abv_overrides,
         );
+        return $this->add_nutrition( $result, $args, $abv_overrides );
     }
 
     public function pitcher( $args ) {
@@ -335,14 +417,15 @@ class MM_Calculator {
         );
         $amounts = $this->apply_flavour( $amounts, $flavour_key, $scale );
         $total_ml = $amounts['tequila_ml'] + $amounts['citrus_ml'] + $amounts['triple_ml'] + $amounts['agave_ml'] + $amounts['extra_ml'];
-        $meta     = $this->flavour_meta( $flavour_key );
-        $abv      = $meta['no_alcohol'] ? 0 : $this->abv_estimate( $amounts['tequila_ml'], $amounts['triple_ml'], $total_ml, $preset['triple_abv'] ?? 0.40 );
+        $meta          = $this->flavour_meta( $flavour_key );
+        $abv_overrides = $this->normalise_abv_overrides( $args, $preset );
+        $abv           = $meta['no_alcohol'] ? 0 : $this->abv_estimate( $amounts['tequila_ml'], $amounts['triple_ml'], $total_ml, $abv_overrides['triple_sec_abv'] / 100, $abv_overrides['tequila_abv'] / 100 );
         $drinks   = max( 1, (int) round( $pitcher_ml / 90 ) );
         if ( ! empty( $amounts['extra'] ) ) {
             $amounts['extra']['display'] = $this->ml_to_unit( $amounts['extra']['ml'], $unit );
         }
 
-        return array(
+        $result = array(
             'mode'       => 'pitcher',
             'pitcher_ml' => $pitcher_ml,
             'unit'       => $unit,
@@ -359,7 +442,9 @@ class MM_Calculator {
             'preset_label' => $preset['label'] ?? ucfirst( $preset_key ),
             'flavour'    => $meta,
             'suffix'     => $this->unit_suffix( $unit ),
+            'abv_overrides' => $abv_overrides,
         );
+        return $this->add_nutrition( $result, $args, $abv_overrides );
     }
 
 }

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -9,6 +9,7 @@ class MM_Plugin {
     private function __construct() {
         $this->calc = new MM_Calculator();
         add_shortcode( 'margarita_measurements', array( $this, 'render_shortcode' ) );
+        add_shortcode( 'margarita_widget', array( $this, 'render_widget_shortcode' ) );
         add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_frontend' ) );
         add_action( 'init', array( $this, 'register_block' ) );
     }
@@ -22,16 +23,16 @@ class MM_Plugin {
         ) );
     }
     protected function sanitize_bool( $value, $fallback = true ) {
-        if ( is_bool( $value ) ) {
-            return $value;
-        }
-        if ( '' === $value || null === $value ) {
-            return $fallback;
-        }
+        if ( is_bool( $value ) ) { return $value; }
+        if ( '' === $value || null === $value ) { return $fallback; }
         return in_array( strtolower( (string) $value ), array( '1', 'true', 'yes', 'on' ), true );
     }
+    protected function sanitize_align( $align ) {
+        $align = sanitize_key( $align );
+        return in_array( $align, array( 'none', 'right', 'left', 'center' ), true ) ? $align : 'none';
+    }
 
-    public function sanitize_render_atts( $atts = array() ) {
+    public function sanitize_render_atts( $atts = array(), $shortcode = 'margarita_measurements' ) {
         $default_unit   = get_option( 'mm_unit', 'ml' );
         $default_preset = get_option( 'mm_default_preset', 'classic' );
         $max_drinks     = (int) get_option( 'mm_max_drinks', 25 );
@@ -39,133 +40,110 @@ class MM_Plugin {
         $presets        = $this->calc->list_presets();
         $allowed_units  = array( 'ml', 'oz', 'shot', 'nip' );
         $allowed_modes  = array( 'drinks', 'pitcher', 'party' );
+        $is_widget      = 'margarita_widget' === $shortcode;
 
         $atts = shortcode_atts(
             array(
-                'preset'   => $default_preset,
-                'unit'     => $default_unit,
-                'flavour'  => 'none',
-                'drinks'   => 1,
-                'show_abv' => $admin_show_abv ? 'true' : 'false',
-                'mode'     => 'drinks',
-                'title'    => __( 'Margarita Measurements', 'margarita-measurements' ),
+                'preset'         => $default_preset,
+                'unit'           => $default_unit,
+                'flavour'        => 'none',
+                'drinks'         => 1,
+                'show_abv'       => $is_widget ? 'false' : ( $admin_show_abv ? 'true' : 'false' ),
+                'show_nutrition' => $is_widget ? 'false' : 'true',
+                'mode'           => 'drinks',
+                'title'          => $is_widget ? __( 'Margarita calculator', 'margarita-measurements' ) : __( 'Margarita Measurements', 'margarita-measurements' ),
+                'tequila_abv'    => 40,
+                'triple_sec_abv' => 40,
+                'standard_region'=> 'AU',
+                'align'          => 'none',
             ),
             $atts,
-            'margarita_measurements'
+            $shortcode
         );
 
         $preset = sanitize_key( $atts['preset'] );
         $preset = isset( $presets[ $preset ] ) ? $preset : ( isset( $presets[ $default_preset ] ) ? $default_preset : 'classic' );
         $unit   = sanitize_key( $atts['unit'] );
         $unit   = in_array( $unit, $allowed_units, true ) ? $unit : ( in_array( $default_unit, $allowed_units, true ) ? $default_unit : 'ml' );
-        $mode   = sanitize_key( $atts['mode'] );
+        $mode   = $is_widget ? 'drinks' : sanitize_key( $atts['mode'] );
         $mode   = in_array( $mode, $allowed_modes, true ) ? $mode : 'drinks';
         $drinks = min( max( 1, absint( $atts['drinks'] ) ), max( 1, $max_drinks ) );
         $title  = sanitize_text_field( $atts['title'] );
 
         return array(
-            'preset'   => $preset,
-            'unit'     => $unit,
-            'flavour'  => $this->calc->normalise_flavour_key( $atts['flavour'] ),
-            'drinks'   => $drinks,
-            'show_abv' => $this->sanitize_bool( $atts['show_abv'], $admin_show_abv ),
-            'mode'     => $mode,
-            'title'    => '' === $title ? __( 'Margarita Measurements', 'margarita-measurements' ) : $title,
+            'preset'          => $preset,
+            'unit'            => $unit,
+            'flavour'         => $this->calc->normalise_flavour_key( $atts['flavour'] ),
+            'drinks'          => $drinks,
+            'show_abv'        => $this->sanitize_bool( $atts['show_abv'], ! $is_widget && $admin_show_abv ),
+            'show_nutrition'  => $this->sanitize_bool( $atts['show_nutrition'], ! $is_widget ),
+            'mode'            => $mode,
+            'title'           => '' === $title ? ( $is_widget ? __( 'Margarita calculator', 'margarita-measurements' ) : __( 'Margarita Measurements', 'margarita-measurements' ) ) : $title,
+            'tequila_abv'     => $this->calc->sanitize_tequila_abv( $atts['tequila_abv'] ),
+            'triple_sec_abv'  => $this->calc->sanitize_triple_sec_abv( $atts['triple_sec_abv'] ),
+            'standard_region' => $this->calc->normalise_standard_drink_region( $atts['standard_region'] ),
+            'align'           => $this->sanitize_align( $atts['align'] ),
         );
     }
 
     protected function block_attributes_to_shortcode_atts( $attributes ) {
         $atts = array();
         foreach ( array( 'preset', 'unit', 'flavour', 'mode', 'title' ) as $key ) {
-            if ( isset( $attributes[ $key ] ) ) {
-                $atts[ $key ] = $attributes[ $key ];
-            }
+            if ( isset( $attributes[ $key ] ) ) { $atts[ $key ] = $attributes[ $key ]; }
         }
-        if ( array_key_exists( 'showAbv', $attributes ) ) {
-            $atts['show_abv'] = $attributes['showAbv'] ? 'true' : 'false';
-        }
+        if ( array_key_exists( 'showAbv', $attributes ) ) { $atts['show_abv'] = $attributes['showAbv'] ? 'true' : 'false'; }
         return $atts;
     }
 
-    public function render_shortcode( $atts = array() ) {
+    public function render_widget_shortcode( $atts = array() ) {
+        return $this->render_shortcode( $atts, 'widget' );
+    }
+
+    public function render_shortcode( $atts = array(), $context = 'full' ) {
         wp_enqueue_style( 'mm-frontend' );
         wp_enqueue_style( 'mm-print' );
         wp_enqueue_script( 'mm-frontend' );
 
+        $is_widget = 'widget' === $context;
+        $shortcode = $is_widget ? 'margarita_widget' : 'margarita_measurements';
         $max_drinks = (int) get_option( 'mm_max_drinks', 25 );
-        $default_standard_drink_region = $this->calc->normalise_standard_drink_region( get_option( 'mm_standard_drink_region', 'AU' ) );
         $presets   = $this->calc->list_presets();
         $flavours  = $this->calc->list_flavours();
-        $atts      = $this->sanitize_render_atts( $atts );
-
-        $preset   = $atts['preset'];
-        $unit     = $atts['unit'];
-        $mode     = $atts['mode'];
-        $drinks   = $atts['drinks'];
-        $show_abv = $atts['show_abv'];
-        $flavour  = $atts['flavour'];
-        $title    = $atts['title'];
-        $instance = wp_unique_id( 'mm-' );
+        $atts      = $this->sanitize_render_atts( $atts, $shortcode );
+        $instance  = wp_unique_id( 'mm-' );
+        $wrap_classes = array( 'mm-wrap' );
+        if ( $is_widget ) {
+            $wrap_classes[] = 'mm-widget';
+            $wrap_classes[] = 'mm-widget--align-' . $atts['align'];
+        }
         ob_start(); ?>
-        <div class="mm-wrap">
+        <div class="<?php echo esc_attr( implode( ' ', $wrap_classes ) ); ?>">
             <form class="mm-form" aria-describedby="<?php echo esc_attr( $instance ); ?>-help" novalidate>
-                <h2 class="mm-title"><?php echo esc_html( $title ); ?></h2>
+                <h2 class="<?php echo esc_attr( $is_widget ? 'mm-widget__title' : 'mm-title' ); ?>"><?php echo esc_html( $atts['title'] ); ?></h2>
                 <div class="mm-row">
-                    <label for="<?php echo esc_attr( $instance ); ?>-preset"><?php echo esc_html__( 'Preset', 'margarita-measurements' ); ?></label>
-                    <select id="<?php echo esc_attr( $instance ); ?>-preset" name="preset">
-                        <?php foreach ( $presets as $key => $p ): ?>
-                            <option value="<?php echo esc_attr( $key ); ?>" <?php selected( $key, $preset ); ?>>
-                                <?php echo esc_html( $p['label'] ?? ucfirst( $key ) ); ?>
-                            </option>
-                        <?php endforeach; ?>
-                    </select>
+                    <label for="<?php echo esc_attr( $instance ); ?>-preset"><?php esc_html_e( 'Preset', 'margarita-measurements' ); ?></label>
+                    <select id="<?php echo esc_attr( $instance ); ?>-preset" name="preset"><?php foreach ( $presets as $key => $p ) : ?><option value="<?php echo esc_attr( $key ); ?>" <?php selected( $key, $atts['preset'] ); ?>><?php echo esc_html( $p['label'] ?? ucfirst( $key ) ); ?></option><?php endforeach; ?></select>
                 </div>
                 <div class="mm-row">
-                    <label for="<?php echo esc_attr( $instance ); ?>-flavour"><?php echo esc_html__( 'Flavour', 'margarita-measurements' ); ?></label>
-                    <select id="<?php echo esc_attr( $instance ); ?>-flavour" name="flavour">
-                        <?php foreach ( $flavours as $key => $f ): ?>
-                            <option value="<?php echo esc_attr( $key ); ?>" <?php selected( $key, $flavour ); ?>><?php echo esc_html( $f['label'] ); ?></option>
-                        <?php endforeach; ?>
-                    </select>
+                    <label for="<?php echo esc_attr( $instance ); ?>-flavour"><?php esc_html_e( 'Flavour', 'margarita-measurements' ); ?></label>
+                    <select id="<?php echo esc_attr( $instance ); ?>-flavour" name="flavour"><?php foreach ( $flavours as $key => $f ) : ?><option value="<?php echo esc_attr( $key ); ?>" <?php selected( $key, $atts['flavour'] ); ?>><?php echo esc_html( $f['label'] ); ?></option><?php endforeach; ?></select>
                 </div>
-                <div class="mm-row">
-                    <label for="<?php echo esc_attr( $instance ); ?>-drinks"><?php echo esc_html__( 'Drinks', 'margarita-measurements' ); ?></label>
-                    <input id="<?php echo esc_attr( $instance ); ?>-drinks" name="drinks" type="number" min="1" max="<?php echo esc_attr( $max_drinks ); ?>" value="<?php echo esc_attr( $drinks ); ?>" />
-                </div>
-                <div class="mm-row">
-                    <label for="<?php echo esc_attr( $instance ); ?>-mode"><?php esc_html_e( 'Mode', 'margarita-measurements' ); ?></label>
-                    <select id="<?php echo esc_attr( $instance ); ?>-mode" name="mode">
-                        <option value="drinks" <?php selected( 'drinks', $mode ); ?>><?php esc_html_e( 'Per drink count', 'margarita-measurements' ); ?></option>
-                        <option value="pitcher" <?php selected( 'pitcher', $mode ); ?>><?php esc_html_e( 'Pitcher (total ml)', 'margarita-measurements' ); ?></option>
-                        <option value="party" <?php selected( 'party', $mode ); ?>><?php esc_html_e( 'Party Planning', 'margarita-measurements' ); ?></option>
-                    </select>
-                </div>
-                <div class="mm-row mm-pitcher-row"<?php echo 'pitcher' === $mode ? '' : ' style="display:none;"'; ?>>
-                    <label for="<?php echo esc_attr( $instance ); ?>-pitcher"><?php esc_html_e( 'Pitcher size (ml)', 'margarita-measurements' ); ?></label>
-                    <input id="<?php echo esc_attr( $instance ); ?>-pitcher" name="pitcher_ml" type="number" min="100" max="5000" step="50" value="1000" />
-                </div>
-                <div class="mm-party-fields"<?php echo 'party' === $mode ? '' : ' style="display:none;"'; ?>>
-                    <div class="mm-row"><label for="<?php echo esc_attr( $instance ); ?>-guests"><?php esc_html_e( 'Guests', 'margarita-measurements' ); ?></label><input id="<?php echo esc_attr( $instance ); ?>-guests" name="guests" type="number" min="1" max="500" value="10" /></div>
-                    <div class="mm-row"><label for="<?php echo esc_attr( $instance ); ?>-drinks-person"><?php esc_html_e( 'Drinks per person', 'margarita-measurements' ); ?></label><input id="<?php echo esc_attr( $instance ); ?>-drinks-person" name="drinks_per_person" type="number" min="0.1" max="12" step="0.1" value="2" /></div>
-                    <div class="mm-row"><label for="<?php echo esc_attr( $instance ); ?>-duration"><?php esc_html_e( 'Event duration (hours)', 'margarita-measurements' ); ?></label><input id="<?php echo esc_attr( $instance ); ?>-duration" name="event_duration" type="number" min="0.5" max="24" step="0.5" value="2" /></div>
-                    <div class="mm-row"><label for="<?php echo esc_attr( $instance ); ?>-standard-region"><?php esc_html_e( 'Standard drink', 'margarita-measurements' ); ?></label><select id="<?php echo esc_attr( $instance ); ?>-standard-region" name="standard_drink_region"><?php foreach ( $this->calc->standard_drink_regions() as $region => $details ) : ?><option value="<?php echo esc_attr( $region ); ?>" <?php selected( $default_standard_drink_region, $region ); ?>><?php echo esc_html( $details['label'] ); ?></option><?php endforeach; ?></select></div>
-                </div>
-                <div class="mm-row">
-                    <label><input type="checkbox" name="wet_rim" value="1" checked /> <?php esc_html_e( 'Wet rim (more salt)', 'margarita-measurements' ); ?></label>
-                </div>
-                <fieldset class="mm-fieldset">
-                    <legend><?php echo esc_html__( 'Units', 'margarita-measurements' ); ?></legend>
-                    <?php foreach ( array( 'ml' => 'ml', 'oz' => 'oz', 'shot' => 'Shot', 'nip' => 'Nip' ) as $val => $label ) : ?>
-                        <label class="mm-radio"><input type="radio" name="unit" value="<?php echo esc_attr( $val ); ?>" <?php checked( $val, $unit ); ?> /> <span><?php echo esc_html( $label ); ?></span></label>
-                    <?php endforeach; ?>
-                </fieldset>
-                <input type="hidden" name="action" value="mm_calculate" />
-                <input type="hidden" name="show_abv" value="<?php echo esc_attr( $show_abv ? '1' : '0' ); ?>" />
-                <input type="hidden" name="nonce" value="<?php echo esc_attr( wp_create_nonce( 'mm_nonce' ) ); ?>" />
-                <button type="submit" class="mm-btn"><?php echo esc_html__( 'Calculate', 'margarita-measurements' ); ?></button>
+                <div class="mm-row"><label for="<?php echo esc_attr( $instance ); ?>-drinks"><?php esc_html_e( 'Drinks', 'margarita-measurements' ); ?></label><input id="<?php echo esc_attr( $instance ); ?>-drinks" name="drinks" type="number" min="1" max="<?php echo esc_attr( $max_drinks ); ?>" value="<?php echo esc_attr( $atts['drinks'] ); ?>" /></div>
+                <?php if ( ! $is_widget ) : ?>
+                    <div class="mm-row"><label for="<?php echo esc_attr( $instance ); ?>-mode"><?php esc_html_e( 'Mode', 'margarita-measurements' ); ?></label><select id="<?php echo esc_attr( $instance ); ?>-mode" name="mode"><option value="drinks" <?php selected( 'drinks', $atts['mode'] ); ?>><?php esc_html_e( 'Per drink count', 'margarita-measurements' ); ?></option><option value="pitcher" <?php selected( 'pitcher', $atts['mode'] ); ?>><?php esc_html_e( 'Pitcher (total ml)', 'margarita-measurements' ); ?></option><option value="party" <?php selected( 'party', $atts['mode'] ); ?>><?php esc_html_e( 'Party Planning', 'margarita-measurements' ); ?></option></select></div>
+                    <div class="mm-row mm-pitcher-row"<?php echo 'pitcher' === $atts['mode'] ? '' : ' style="display:none;"'; ?>><label for="<?php echo esc_attr( $instance ); ?>-pitcher"><?php esc_html_e( 'Pitcher size (ml)', 'margarita-measurements' ); ?></label><input id="<?php echo esc_attr( $instance ); ?>-pitcher" name="pitcher_ml" type="number" min="100" max="5000" step="50" value="1000" /></div>
+                    <div class="mm-party-fields"<?php echo 'party' === $atts['mode'] ? '' : ' style="display:none;"'; ?>><div class="mm-row"><label for="<?php echo esc_attr( $instance ); ?>-guests"><?php esc_html_e( 'Guests', 'margarita-measurements' ); ?></label><input id="<?php echo esc_attr( $instance ); ?>-guests" name="guests" type="number" min="1" max="500" value="10" /></div><div class="mm-row"><label for="<?php echo esc_attr( $instance ); ?>-drinks-person"><?php esc_html_e( 'Drinks per person', 'margarita-measurements' ); ?></label><input id="<?php echo esc_attr( $instance ); ?>-drinks-person" name="drinks_per_person" type="number" min="0.1" max="12" step="0.1" value="2" /></div><div class="mm-row"><label for="<?php echo esc_attr( $instance ); ?>-duration"><?php esc_html_e( 'Event duration (hours)', 'margarita-measurements' ); ?></label><input id="<?php echo esc_attr( $instance ); ?>-duration" name="event_duration" type="number" min="0.5" max="24" step="0.5" value="2" /></div></div>
+                    <details class="mm-details mm-advanced"><summary><?php esc_html_e( 'Advanced', 'margarita-measurements' ); ?></summary><div class="mm-row"><label for="<?php echo esc_attr( $instance ); ?>-tequila-abv"><?php esc_html_e( 'Tequila ABV %', 'margarita-measurements' ); ?></label><input id="<?php echo esc_attr( $instance ); ?>-tequila-abv" name="tequila_abv" type="number" min="35" max="55" step="0.1" value="<?php echo esc_attr( $atts['tequila_abv'] ); ?>" /></div><div class="mm-row"><label for="<?php echo esc_attr( $instance ); ?>-triple-sec-abv"><?php esc_html_e( 'Triple sec ABV %', 'margarita-measurements' ); ?></label><input id="<?php echo esc_attr( $instance ); ?>-triple-sec-abv" name="triple_sec_abv" type="number" min="15" max="45" step="0.1" value="<?php echo esc_attr( $atts['triple_sec_abv'] ); ?>" /></div><div class="mm-row"><label for="<?php echo esc_attr( $instance ); ?>-standard-region"><?php esc_html_e( 'Standard drink', 'margarita-measurements' ); ?></label><select id="<?php echo esc_attr( $instance ); ?>-standard-region" name="standard_region"><?php foreach ( $this->calc->standard_drink_regions() as $region => $details ) : ?><option value="<?php echo esc_attr( $region ); ?>" <?php selected( $atts['standard_region'], $region ); ?>><?php echo esc_html( $details['label'] ); ?></option><?php endforeach; ?></select></div></details>
+                    <div class="mm-row"><label><input type="checkbox" name="wet_rim" value="1" checked /> <?php esc_html_e( 'Wet rim (more salt)', 'margarita-measurements' ); ?></label></div>
+                <?php else : ?>
+                    <input type="hidden" name="mode" value="drinks" /><input type="hidden" name="tequila_abv" value="<?php echo esc_attr( $atts['tequila_abv'] ); ?>" /><input type="hidden" name="triple_sec_abv" value="<?php echo esc_attr( $atts['triple_sec_abv'] ); ?>" /><input type="hidden" name="standard_region" value="<?php echo esc_attr( $atts['standard_region'] ); ?>" />
+                <?php endif; ?>
+                <fieldset class="mm-fieldset"><legend><?php esc_html_e( 'Units', 'margarita-measurements' ); ?></legend><?php foreach ( array( 'ml' => 'ml', 'oz' => 'oz', 'shot' => 'Shot', 'nip' => 'Nip' ) as $val => $label ) : ?><label class="mm-radio"><input type="radio" name="unit" value="<?php echo esc_attr( $val ); ?>" <?php checked( $val, $atts['unit'] ); ?> /> <span><?php echo esc_html( $label ); ?></span></label><?php endforeach; ?></fieldset>
+                <input type="hidden" name="action" value="mm_calculate" /><input type="hidden" name="show_abv" value="<?php echo esc_attr( $atts['show_abv'] ? '1' : '0' ); ?>" /><input type="hidden" name="show_nutrition" value="<?php echo esc_attr( $atts['show_nutrition'] ? '1' : '0' ); ?>" /><input type="hidden" name="nonce" value="<?php echo esc_attr( wp_create_nonce( 'mm_nonce' ) ); ?>" />
+                <button type="submit" class="mm-btn"><?php esc_html_e( 'Calculate', 'margarita-measurements' ); ?></button>
             </form>
-            <div class="mm-results" aria-live="polite"></div>
-            <p id="<?php echo esc_attr( $instance ); ?>-help" class="mm-help"><?php echo esc_html__( 'Tip: switch units, add a flavour, or try presets like Tommy’s or Frozen.', 'margarita-measurements' ); ?></p>
+            <div class="mm-results<?php echo $is_widget ? ' mm-widget__result' : ''; ?>" aria-live="polite"></div>
+            <?php if ( ! $is_widget ) : ?><p id="<?php echo esc_attr( $instance ); ?>-help" class="mm-help"><?php esc_html_e( 'Tip: switch units, add a flavour, or try presets like Tommy’s or Frozen.', 'margarita-measurements' ); ?></p><?php endif; ?>
         </div>
         <?php return ob_get_clean();
     }

--- a/includes/class-rest.php
+++ b/includes/class-rest.php
@@ -21,6 +21,9 @@ class MM_REST {
                 'unit'       => array( 'sanitize_callback' => 'sanitize_text_field' ),
                 'wet_rim'    => array( 'sanitize_callback' => 'rest_sanitize_boolean' ),
                 'flavour'    => array( 'sanitize_callback' => 'sanitize_key' ),
+                'standard_region' => array( 'sanitize_callback' => 'sanitize_key' ),
+                'tequila_abv' => array( 'sanitize_callback' => 'floatval' ),
+                'triple_sec_abv' => array( 'sanitize_callback' => 'floatval' ),
             ),
             'callback' => array( $this, 'calc' ),
         ) );
@@ -53,6 +56,9 @@ class MM_REST {
             'pitcher_ml' => min( 5000, max( 100, (float) ( $request->get_param( 'pitcher_ml' ) ?: 1000 ) ) ),
             'unit'       => $request->get_param( 'unit' ) ?: get_option( 'mm_unit', 'ml' ),
             'flavour'    => $request->get_param( 'flavour' ) ?: 'none',
+            'standard_region' => $request->get_param( 'standard_region' ) ?: 'AU',
+            'tequila_abv' => $request->get_param( 'tequila_abv' ) ?: 40,
+            'triple_sec_abv' => $request->get_param( 'triple_sec_abv' ) ?: 40,
             'wet_rim'    => null === $request->get_param( 'wet_rim' ) ? true : (bool) $request->get_param( 'wet_rim' ),
         );
         $calc            = MM_Plugin::instance()->calc;
@@ -61,6 +67,9 @@ class MM_REST {
         $args['preset']  = in_array( $args['preset'], $allowed_presets, true ) ? $args['preset'] : 'classic';
         $args['unit']    = in_array( $args['unit'], $allowed_units, true ) ? $args['unit'] : get_option( 'mm_unit', 'ml' );
         $args['flavour'] = $calc->normalise_flavour_key( $args['flavour'] );
+        $args['standard_region'] = $calc->normalise_standard_drink_region( $args['standard_region'] );
+        $args['tequila_abv'] = $calc->sanitize_tequila_abv( $args['tequila_abv'] );
+        $args['triple_sec_abv'] = $calc->sanitize_triple_sec_abv( $args['triple_sec_abv'] );
         $mode            = in_array( $mode, array( 'drinks', 'pitcher' ), true ) ? $mode : 'drinks';
         $data            = 'pitcher' === $mode ? $calc->pitcher( $args ) : $calc->batch( $args );
         foreach ( $data['quantities'] as &$v ) {

--- a/margarita-measurements.php
+++ b/margarita-measurements.php
@@ -3,7 +3,7 @@
  * Plugin Name: Margarita Measurements
  * Plugin URI: #
  * Description: Calculate perfect margarita ratios with presets, units, and ABV estimate. Shortcode: [margarita_measurements]. Also provides a Gutenberg block.
- * Version: 2.4.0
+ * Version: 3.0.0
  * Author: Bryan Chetcuti (https://github.com/bchetcuti/margaritaWP)
  * Text Domain: margarita-measurements
  * Requires at least: 5.8
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'MM_VERSION', '2.4.0' );
+define( 'MM_VERSION', '3.0.0' );
 define( 'MM_PLUGIN_FILE', __FILE__ );
 define( 'MM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'MM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );

--- a/readme.txt
+++ b/readme.txt
@@ -1,66 +1,124 @@
 === Margarita Measurements ===
 Contributors: Bryan Chetcuti
+Tags: margarita, cocktail, calculator, bar, drinks
 Requires at least: 5.8
 Tested up to: 7.0
-Stable tag: 2.4.0
+Stable tag: 3.0.0
 Requires PHP: 8.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
-Calculate perfect margarita ratios with presets, unit switching, and ABV estimate. Shortcode and block included.
+A margarita calculator for WordPress with recipe ratios, batch scaling, flavour variations, ABV estimates and embeddable cocktail widgets.
 
 == Description ==
-- Presets: Classic, Tommy’s, Frozen, Skinny
-- Units: ml, oz, shot, nip
-- ABV estimate (toggle)
-- Flavour variations: none, spicy, mango, watermelon, strawberry, coconut, virgin
-- Shortcode attributes for preset, unit, flavour, drinks, show_abv, mode, and title
-- Inline clipboard copy confirmation
-- Themeable CSS variables with dark mode support
-- Gutenberg block + shortcode `[margarita_measurements]`
-- REST endpoint: `/wp-json/margarita/v1/calculate?preset=classic&drinks=4&unit=ml`
-- AJAX form (no page reload), accessible, i18n-ready
-- Uninstall removes options
+Whether you're squeezing limes for two or mixing a larger batch for guests, Margarita Measurements does the maths so you don't have to.
+
+Margarita Measurements helps WordPress sites publish a practical cocktail calculator with preset recipes, unit conversion, flavour variations, pitcher/batch output, print-friendly results, and responsible recipe-planning estimates.
+
+= Who it is for =
+* Home users: scale a classic, Tommy's, frozen or skinny margarita without mental arithmetic.
+* Cocktail bloggers: embed the full calculator or a compact inline widget inside recipe posts.
+* Bars and hospitality: adjust tequila and triple sec ABV to match the bottle being used.
+* Event hosts: use batch, pitcher and party-planning outputs where available to plan ingredients.
+
+= Features =
+* Margarita recipe calculator with Classic, Tommy's, Frozen and Skinny presets.
+* Batch scaling by drink count and pitcher mode by total ml.
+* Unit conversion for ml, oz, shot and nip.
+* Flavour variations: spicy, mango, watermelon, strawberry, coconut and virgin.
+* Salt rim estimate and print recipe card.
+* Optional ABV estimate.
+* Nutrition and standard drinks estimator for AU, UK and US standard-drink definitions.
+* Tequila and triple sec ABV customiser.
+* Full shortcode: `[margarita_measurements]`.
+* Compact recipe-post shortcode: `[margarita_widget]`.
+* Dynamic Gutenberg block for the full calculator.
+* Custom preset builder in the WordPress settings screen.
+* Themeable CSS variables with dark mode support.
+* AJAX form with no page reload.
+* REST endpoint for calculations and preset listings.
+
+= Shortcodes =
+`[margarita_measurements]`
+
+`[margarita_measurements preset="tommys" drinks="4" unit="ml"]`
+
+`[margarita_measurements preset="tommys" drinks="4" tequila_abv="38" standard_region="AU" show_nutrition="true"]`
+
+`[margarita_widget]`
+
+`[margarita_widget preset="classic" drinks="2" align="right"]`
+
+= Privacy =
+Recipe calculations run in WordPress and the browser through the plugin's local AJAX/REST handlers. The plugin does not send recipe calculations to third-party services, does not add analytics, and does not track visitors.
 
 == Installation ==
-1. Upload the ZIP via **Plugins → Add New → Upload Plugin**.
-2. Activate.
-3. Add the shortcode to a page or insert the block.
+1. Upload the ZIP via Plugins > Add New > Upload Plugin.
+2. Activate the plugin.
+3. Add `[margarita_measurements]` to a page, insert the Gutenberg block, or place `[margarita_widget]` inside a recipe post.
 
 == Screenshots ==
-1. Shortcode on a page.
-2. Presets and units.
-3. ABV details.
+1. Full calculator on a light theme.
+2. Result card for a scaled margarita batch.
+3. Flavour selector with margarita variants.
+4. Pitcher or batch output.
+5. Print recipe card output.
+6. Custom preset builder in settings.
+7. Gutenberg block editor view.
+8. Compact `[margarita_widget]` inside a recipe post.
+9. Nutrition and standard drinks panel expanded.
+10. Mobile responsive calculator view.
 
 == Frequently Asked Questions ==
-= Can I change default units or preset? =
-Yes, in **Settings → Margarita Measurements**.
+= Does it work without Gutenberg? =
+Yes. Use the `[margarita_measurements]` shortcode in any shortcode-capable editor, template or widget area.
 
-= Does it support Classic Editor? =
-Yes. The shortcode works anywhere.
+= Can I use it in the Classic Editor? =
+Yes. Paste the shortcode into the Classic Editor content area.
+
+= Can I embed a smaller version inside a recipe post? =
+Yes. Use `[margarita_widget]` for a compact calculator. It supports preset, unit, drinks, flavour, title, show_abv, show_nutrition and align attributes.
+
+= Can I change the tequila ABV? =
+Yes. The Advanced panel includes tequila and triple sec ABV fields, and the shortcode supports `tequila_abv` and `triple_sec_abv` attributes.
+
+= Does it calculate standard drinks? =
+Yes. The nutrition panel estimates alcohol grams and standard drinks using AU (10g), UK (8g) or US (14g) definitions. These are approximate recipe-planning values only.
+
+= Does it store visitor data? =
+No. The plugin does not store visitor recipe calculations or visitor account data.
+
+= Does it call third-party services? =
+No. It does not call third-party APIs or load remote tracking services for calculations.
 
 == Changelog ==
+= 3.0.0 =
+* Added nutrition and standard drinks estimator.
+* Added AU, UK and US standard-drink region support.
+* Added tequila and triple sec ABV customisation.
+* Added compact `[margarita_widget]` shortcode for recipe-post embedding.
+* Refreshed WordPress.org readme positioning.
+
 = 2.4.0 =
-- Feature: Flavour variations for spicy, mango, watermelon, strawberry, coconut, and virgin margaritas.
-- Feature: Shortcode attributes for per-instance preset, unit, flavour, drinks, show_abv, mode, and title overrides.
-- Enhancement: Copy action now uses inline “✓ Copied!” feedback with a clipboard fallback and no alert.
-- Enhancement: Frontend styles now use CSS custom properties and support prefers-color-scheme dark mode.
+* Feature: Flavour variations for spicy, mango, watermelon, strawberry, coconut, and virgin margaritas.
+* Feature: Shortcode attributes for per-instance preset, unit, flavour, drinks, show_abv, mode, and title overrides.
+* Enhancement: Copy action now uses inline "Copied" feedback with a clipboard fallback and no alert.
+* Enhancement: Frontend styles now use CSS custom properties and support prefers-color-scheme dark mode.
 
 = 2.3.0 =
-- WordPress 7.0 compatibility confirmed; bumped Tested up to.
-- Fixed MM_VERSION constant mismatch (was 2.1.0, now 2.3.0).
-- Removed deprecated load_plugin_textdomain call (auto-loaded since WP 4.6).
-- Security: REST and AJAX now clamp drinks to mm_max_drinks and validate preset against allowlist.
-- Security: ABV calculation now uses per-preset triple_abv value (default 0.40).
-- Feature: Custom Preset Builder — create, save, and delete named ratio presets from the Settings page.
-- Feature: Pitcher Mode — calculate total quantities for a given pitcher volume instead of per-drink.
-- Feature: Salt Rim Estimator — displays estimated salt grams and teaspoons per batch (wet/dry toggle).
-- Feature: Print Recipe Card — styled A5 print card injected at print time, no page theme bleed.
+* WordPress 7.0 compatibility confirmed; bumped Tested up to.
+* Fixed MM_VERSION constant mismatch.
+* Security: REST and AJAX now clamp drinks to mm_max_drinks and validate preset against allowlist.
+* Security: ABV calculation now uses per-preset triple_abv value.
+* Feature: Custom Preset Builder, Pitcher Mode, Salt Rim Estimator and Print Recipe Card.
 
 = 2.2.0 =
-- Presets, units, ABV, REST, AJAX, block, settings, uninstall.
-- Minor UI polish and docs update.
+* Presets, units, ABV, REST, AJAX, block, settings and uninstall.
+* Minor UI polish and docs update.
 
+== Upgrade Notice ==
+= 3.0.0 =
+Adds responsible recipe-planning estimates, ABV customisation and a compact widget shortcode for recipe posts.
 
 == License ==
 GPLv2 or later.

--- a/tests/test-calculator.php
+++ b/tests/test-calculator.php
@@ -52,4 +52,28 @@ final class CalculatorTest extends TestCase {
         $this->assertEquals('AU', $out['responsible_drinking']['region']);
         $this->assertGreaterThan(0, $out['garnish_extras']['limes']);
     }
+    public function test_abv_overrides_change_alcohol_estimates() {
+        $c = new MM_Calculator();
+        $base = $c->batch([ 'preset' => 'classic', 'drinks' => 1, 'unit' => 'ml' ]);
+        $strong = $c->batch([ 'preset' => 'classic', 'drinks' => 1, 'unit' => 'ml', 'tequila_abv' => 55, 'triple_sec_abv' => 45 ]);
+        $this->assertGreaterThan($base['abv'], $strong['abv']);
+        $this->assertGreaterThan($base['nutrition']['alcohol_grams'], $strong['nutrition']['alcohol_grams']);
+        $this->assertEquals(55.0, $strong['abv_overrides']['tequila_abv']);
+        $this->assertEquals(45.0, $strong['abv_overrides']['triple_sec_abv']);
+    }
+
+    public function test_nutrition_standard_regions_and_virgin_zero_alcohol() {
+        $c = new MM_Calculator();
+        $au = $c->batch([ 'preset' => 'classic', 'drinks' => 1, 'unit' => 'ml', 'standard_region' => 'AU' ]);
+        $uk = $c->batch([ 'preset' => 'classic', 'drinks' => 1, 'unit' => 'ml', 'standard_region' => 'UK' ]);
+        $this->assertEquals('AU', $au['nutrition']['region']);
+        $this->assertEquals(10.0, $au['nutrition']['standard_drink_grams']);
+        $this->assertEquals(8.0, $uk['nutrition']['standard_drink_grams']);
+        $this->assertGreaterThan($au['nutrition']['standard_drinks'], $uk['nutrition']['standard_drinks']);
+
+        $virgin = $c->batch([ 'preset' => 'classic', 'drinks' => 1, 'unit' => 'ml', 'flavour' => 'virgin' ]);
+        $this->assertEquals(0.0, $virgin['nutrition']['alcohol_grams']);
+        $this->assertEquals(0.0, $virgin['nutrition']['standard_drinks']);
+    }
+
 }


### PR DESCRIPTION
### Motivation

- Make the plugin market-ready by adding lightweight, responsible estimators for calories, alcohol grams and standard drinks and by letting users override spirit strengths for realistic ABV estimates.  
- Provide a compact embeddable widget shortcode so bloggers can insert a low-footprint calculator in posts without duplicating core logic.  
- Prepare WordPress.org-facing documentation and asset planning so the listing accurately reflects implemented features while explicitly avoiding any persistence or sharing functionality.

### Description

- Added ABV sanitisation and estimation helpers in `includes/class-calculator.php` (`sanitize_tequila_abv`, `sanitize_triple_sec_abv`, `normalise_abv_overrides`, `calculate_alcohol_ml`, `calculate_alcohol_grams`, `calculate_standard_drinks`, `calculate_calories`) and integrated a `add_nutrition` step into `batch()`, `pitcher()` and `party()` results so `nutrition` metadata is returned with calculations.  
- Wire-up of ABV/standard-region controls to server endpoints: REST and AJAX now accept `tequila_abv`, `triple_sec_abv`, and `standard_region` and the AJAX handler respects `show_nutrition`; inputs are sanitised and clamped on both front and back ends.  
- Frontend changes reuse core results and render a collapsed `<details>` nutrition panel via `assets/js/frontend.js` (new `nutritionDetails()`), and added compact widget styling and alignment classes in `assets/css/frontend.css` (`.mm-widget`, `.mm-widget--align-*`, `.mm-nutrition` grid).  
- Added a compact shortcode `margarita_widget` that reuses the existing renderer with a `widget` context and minimal defaults and added a small Advanced panel to the full form for ABV and standard-region controls in `includes/class-plugin.php`.  
- Updated plugin version to `3.0.0`, refreshed `readme.txt` to reflect implemented v3 features and privacy stance, and added `assets-wporg/README.md` with listing/asset guidance.  
- Extended unit tests in `tests/test-calculator.php` to confirm ABV overrides, AU/UK standard-drink handling and virgin recipes produce zero alcohol values.

### Testing

- Ran PHP lint checks with `php -l` across the main plugin and all `includes/*.php` and `tests/test-calculator.php`, and all checked files reported no syntax errors.  
- Ran `node --check assets/js/frontend.js` to validate the frontend JS and it returned no syntax errors.  
- Executed an inline PHP sanity script (via `php -r` requiring `tests/bootstrap.php`) that invoked `MM_Calculator::batch()` to assert AU/UK region grams, virgin zero alcohol, and that stronger ABV overrides increase `abv` and `nutrition.alcohol_grams`, and those checks passed.  
- `phpunit -c tests/phpunit.xml` was not available in this environment so the formal test runner was skipped (environment constraint).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ddbe1dc3c832baa8d9597348d36ec)