### PR TITLE
Prepare v3.0.0 release hygiene

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,9 @@ jobs:
             echo 'Plugin header OK' . PHP_EOL;
           "
 
+      - name: PHP syntax check
+        run: find . -name "*.php" -not -path "./dist/*" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l
+
       - name: Stage plugin files
         run: |
           mkdir -p dist/margarita-measurements

--- a/README.md
+++ b/README.md
@@ -1,55 +1,125 @@
-# 🍸 Margarita Measurements
+# Margarita Measurements
 
-Interactive WordPress plugin to calculate the perfect Margarita cocktail ratios — with presets, unit switching, and ABV estimates. Works as a **shortcode** or **Gutenberg block**.
+Margarita Measurements is a WordPress plugin for publishing an interactive margarita recipe calculator. Version 3.0.0 focuses on recipe ratios, batch scaling, flavour variations, ABV estimates, standard-drink estimates, and embeddable calculator views for WordPress content.
 
-![Banner](assets-wporg/banner-772x250.png)
+For the WordPress.org directory-format listing, see [`readme.txt`](readme.txt). That file is the canonical plugin-directory readme for submission metadata, screenshots, FAQ, changelog, and upgrade notices.
 
-## ✨ Features
-- Presets: **Classic**, **Tommy’s**, **Frozen**, **Skinny**
-- Units: **ml**, **oz**, **shot**, **nip**
-- ABV estimate (toggle in settings)
-- AJAX form (no page reload), accessible, responsive
-- Shortcode: `[margarita_measurements]`
-- Gutenberg block: **Margarita Measurements**
-- REST endpoint:
-  ```
-  /wp-json/margarita/v1/calculate?preset=classic&drinks=4&unit=ml
-  ```
-- Uninstall cleanup, i18n-ready
+## Features
 
-## 🚀 Installation
-1. Download or clone this repository.
-2. Upload to `wp-content/plugins`.
-3. Activate via **Plugins → Installed Plugins**.
-4. Insert shortcode or use the block.
+- Full margarita calculator shortcode for pages and posts.
+- Compact recipe-post widget shortcode for inline use in articles.
+- Dynamic Gutenberg block that renders the full calculator on the frontend.
+- Built-in presets for Classic, Tommy's, Frozen, and Skinny margaritas.
+- Custom preset builder in the WordPress settings screen.
+- Batch scaling by drink count plus pitcher and party-planning modes.
+- Unit conversion for ml, oz, shot, and nip.
+- Flavour variations for spicy, mango, watermelon, strawberry, coconut, and virgin margaritas.
+- Optional ABV estimate with tequila and triple sec ABV controls.
+- Nutrition and standard-drink estimates for AU, UK, and US standard-drink definitions.
+- Salt-rim estimate, print-friendly recipe card output, responsive styles, and dark-mode-aware CSS variables.
+- Local AJAX calculations and REST endpoints for calculation and preset data.
 
-## ⚙️ Settings
-- Default unit
-- Default preset
-- Max drinks per calculation
-- Toggle ABV display
+## Requirements
 
-## 📸 Screenshots
-1. Shortcode on a page  
-   ![](assets-wporg/screenshot-1.png)
-2. Presets and units  
-   ![](assets-wporg/screenshot-2.png)
-3. ABV details  
-   ![](assets-wporg/screenshot-3.png)
+- WordPress: 5.8 or later.
+- PHP: 8.1 or later.
+- Plugin version: 3.0.0.
 
-## 🧑‍💻 Development
-- PHP 7.4+, WP 5.8+
-- PHPUnit (optional)
-- PHPCS (WordPress standards)
+These requirements should stay aligned with the plugin header in `margarita-measurements.php` and the WordPress.org `readme.txt` metadata.
 
-### Commands
-```bash
-vendor/bin/phpunit
-phpcs --standard=WordPress .
+## Installation from source
+
+1. Clone or download this repository.
+2. Copy the repository directory to `wp-content/plugins/margarita-measurements` in a WordPress install.
+3. Activate **Margarita Measurements** from **Plugins → Installed Plugins**.
+4. Add the shortcode to content or insert the block from the block editor.
+
+## Shortcodes
+
+Full calculator:
+
+```text
+[margarita_measurements]
 ```
 
-## 🤝 Contributing
-See [CONTRIBUTING.md](CONTRIBUTING.md). PRs welcome.
+Full calculator with defaults:
 
-## 📜 License
-GPL v2 or later. See [LICENSE](LICENSE).
+```text
+[margarita_measurements preset="tommys" drinks="4" unit="ml"]
+```
+
+Full calculator with ABV and standard-drink options:
+
+```text
+[margarita_measurements preset="tommys" drinks="4" tequila_abv="38" standard_region="AU" show_nutrition="true"]
+```
+
+Compact recipe widget:
+
+```text
+[margarita_widget]
+```
+
+Compact widget with alignment and defaults:
+
+```text
+[margarita_widget preset="classic" drinks="2" align="right"]
+```
+
+## Gutenberg block
+
+The plugin registers a dynamic **Margarita Measurements** block. The block editor script uses WordPress editor packages, and the block assets are registered from the `block/` directory without adding a separate build step.
+
+## Settings summary
+
+The WordPress settings screen supports:
+
+- Default unit.
+- Default preset.
+- Maximum drinks per calculation.
+- ABV display toggle.
+- Standard-drink region default.
+- Bottle-size defaults for planning output.
+- Custom margarita presets.
+
+## Privacy and external services
+
+Margarita Measurements does not add analytics, tracking, visitor accounts, saved visitor recipes, URL sharing, remote API calls, or third-party calculation services. Recipe calculations run in the browser and through the plugin's local WordPress AJAX/REST handlers.
+
+## Architecture notes
+
+- `margarita-measurements.php` contains the plugin header, constants, autoloader, activation defaults, and bootstrap hooks.
+- `includes/class-plugin.php` renders shortcodes, registers frontend assets, and registers the dynamic block.
+- `includes/class-calculator.php` contains recipe, unit, ABV, nutrition, standard-drink, and planning calculations.
+- `includes/class-settings.php` registers and sanitizes admin settings.
+- `includes/class-rest.php` exposes REST endpoints for presets and calculations.
+- `includes/class-ajax.php` handles frontend AJAX calculations and admin custom-preset deletion.
+- `block/` contains block metadata, editor script/style, frontend block style, and editor asset dependencies.
+- `languages/` contains the translation template.
+- `assets-wporg/` documents WordPress.org listing artwork planning; those assets are not part of the plugin runtime.
+
+## Development and testing
+
+Useful local checks before packaging:
+
+```bash
+find . -name "*.php" -not -path "./dist/*" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l
+```
+
+```bash
+vendor/bin/phpunit -c tests/phpunit.xml
+```
+
+```bash
+wp i18n make-pot . languages/margarita-measurements.pot --exclude=dist,tests,.git,node_modules,vendor
+```
+
+PHPUnit and WP-CLI depend on the local development environment; the repository does not vendor large development dependencies.
+
+## WordPress.org release notes
+
+Before WordPress.org submission, the owner still needs to confirm the final WordPress.org contributor username, final Plugin URI/Author URI decisions if they change, final banner/icon/screenshot artwork, and the actual WordPress.org submission workflow.
+
+## License
+
+GPLv2 or later. See [`LICENSE`](LICENSE).

--- a/assets-wporg/README.md
+++ b/assets-wporg/README.md
@@ -1,32 +1,73 @@
 # WordPress.org asset plan
 
-This directory is for WordPress.org listing assets. Existing PNG assets may be replaced before release if updated artwork is produced; do not load these assets remotely from the plugin frontend.
+This directory is a repository planning area for WordPress.org listing artwork. WordPress.org SVN expects public listing assets in a top-level `assets` directory beside `trunk`, not inside the plugin package that is uploaded or copied into `trunk`.
 
-## Banner
+Expected SVN layout:
 
-- File: `banner-1544x500.png` or `banner-1544x500.jpg`
-- Size: 1544 × 500 px
-- Concept: clean cream/warm white background, lime wedge illustration, plugin name, and tagline: “Perfect ratios. Every time.”
+```text
+margarita-measurements/
+├── assets/
+│   ├── banner-772x250.png
+│   ├── banner-1544x500.png
+│   ├── icon-128x128.png
+│   ├── icon-256x256.png
+│   ├── screenshot-1.png
+│   ├── screenshot-2.png
+│   ├── screenshot-3.png
+│   ├── screenshot-4.png
+│   ├── screenshot-5.png
+│   ├── screenshot-6.png
+│   ├── screenshot-7.png
+│   ├── screenshot-8.png
+│   ├── screenshot-9.png
+│   └── screenshot-10.png
+└── trunk/
+    └── plugin files
+```
 
-## Icon
+## Required artwork decisions
 
-- File: `icon-256x256.png`
-- Size: 256 × 256 px
-- Concept: stylised margarita glass silhouette, geometric, two-colour, readable at small sizes.
+The final WordPress.org submission should include owner-approved artwork. Do not generate placeholder binary image files for missing assets.
 
-## Screenshot storyboard
+## Expected files
 
-Recommended files:
+- `assets/banner-772x250.png`
+- `assets/banner-1544x500.png`
+- `assets/icon-128x128.png`
+- `assets/icon-256x256.png`
+- `assets/screenshot-1.png`
+- `assets/screenshot-2.png`
+- `assets/screenshot-3.png`
+- `assets/screenshot-4.png`
+- `assets/screenshot-5.png`
+- `assets/screenshot-6.png`
+- `assets/screenshot-7.png`
+- `assets/screenshot-8.png`
+- `assets/screenshot-9.png`
+- `assets/screenshot-10.png`
 
-1. `screenshot-1.png` — clean full calculator on a light theme.
-2. `screenshot-2.png` — result card for 4 drinks using Tommy’s.
-3. `screenshot-3.png` — flavour selector showing implemented variants.
-4. `screenshot-4.png` — pitcher or batch output.
-5. `screenshot-5.png` — print recipe card output.
-6. `screenshot-6.png` — custom preset builder in settings.
-7. `screenshot-7.png` — Gutenberg block/sidebar view.
-8. `screenshot-8.png` — compact `[margarita_widget]` inside a recipe post.
-9. `screenshot-9.png` — nutrition and standard drinks panel expanded.
-10. `screenshot-10.png` — mobile responsive view.
+## Current repository status
 
-Do not add screenshots for unimplemented visitor account, sharing, analytics, or data-storage features unless those features are implemented in a later release.
+This repository currently includes planning/source copies under `assets-wporg/`. At release time, copy only final, owner-approved files into the WordPress.org SVN `assets/` directory. Do not describe screenshots as complete in the WordPress.org listing unless the corresponding final image files actually exist in SVN.
+
+Currently present in this repository:
+
+- `assets-wporg/banner-772x250.png`
+- `assets-wporg/banner-1544x500.png`
+- `assets-wporg/icon-128x128.png`
+- `assets-wporg/icon-256x256.png`
+- `assets-wporg/screenshot-1.png`
+- `assets-wporg/screenshot-2.png`
+- `assets-wporg/screenshot-3.png`
+- `assets-wporg/screenshot-4.png`
+
+Still requiring final owner-provided artwork before submission:
+
+- `screenshot-5.png`
+- `screenshot-6.png`
+- `screenshot-7.png`
+- `screenshot-8.png`
+- `screenshot-9.png`
+- `screenshot-10.png`
+
+Do not add screenshots for unimplemented visitor account, sharing, analytics, remote-service, or saved-recipe features unless those features are implemented in a later release.

--- a/block/editor.asset.php
+++ b/block/editor.asset.php
@@ -1,0 +1,11 @@
+<?php
+return array(
+    'dependencies' => array(
+        'wp-blocks',
+        'wp-element',
+        'wp-block-editor',
+        'wp-components',
+        'wp-api-fetch',
+    ),
+    'version' => '3.0.0',
+);

--- a/includes/class-ajax.php
+++ b/includes/class-ajax.php
@@ -1,4 +1,8 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
 class MM_Ajax {
     private static $instance = null;
     public static function instance() { if ( null === self::$instance ) { self::$instance = new self(); } return self::$instance; }

--- a/includes/class-calculator.php
+++ b/includes/class-calculator.php
@@ -1,4 +1,8 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
 class MM_Calculator {
     protected $presets = array(
         'classic' => array(

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -1,4 +1,8 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
 class MM_Plugin {
     private static $instance = null;
     public $calc;

--- a/includes/class-rest.php
+++ b/includes/class-rest.php
@@ -1,4 +1,8 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
 class MM_REST {
     private static $instance = null;
     public static function instance() { if ( null === self::$instance ) { self::$instance = new self(); } return self::$instance; }

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -1,4 +1,8 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
 class MM_Settings {
     private static $instance = null;
     public static function instance() {

--- a/languages/margarita-measurements.pot
+++ b/languages/margarita-measurements.pot
@@ -1,5 +1,5 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: Margarita Measurements 2.0.0\n"
+"Project-Id-Version: Margarita Measurements 3.0.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Language: \n"

--- a/margarita-measurements.php
+++ b/margarita-measurements.php
@@ -1,10 +1,10 @@
 <?php
 /**
  * Plugin Name: Margarita Measurements
- * Plugin URI: #
+ * Plugin URI: https://github.com/bchetcuti/margaritaWP
  * Description: Calculate perfect margarita ratios with presets, units, and ABV estimate. Shortcode: [margarita_measurements]. Also provides a Gutenberg block.
  * Version: 3.0.0
- * Author: Bryan Chetcuti (https://github.com/bchetcuti/margaritaWP)
+ * Author: Bryan Chetcuti
  * Text Domain: margarita-measurements
  * Requires at least: 5.8
  * Requires PHP: 8.1

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === Margarita Measurements ===
-Contributors: Bryan Chetcuti
+Contributors: TODO-wordpress-org-username
 Tags: margarita, cocktail, calculator, bar, drinks
 Requires at least: 5.8
 Tested up to: 7.0
@@ -62,12 +62,6 @@ Recipe calculations run in WordPress and the browser through the plugin's local 
 2. Result card for a scaled margarita batch.
 3. Flavour selector with margarita variants.
 4. Pitcher or batch output.
-5. Print recipe card output.
-6. Custom preset builder in settings.
-7. Gutenberg block editor view.
-8. Compact `[margarita_widget]` inside a recipe post.
-9. Nutrition and standard drinks panel expanded.
-10. Mobile responsive calculator view.
 
 == Frequently Asked Questions ==
 = Does it work without Gutenberg? =

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,4 +1,7 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) {
+    define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
 // Minimal bootstrap placeholder for CI.
 if ( ! function_exists( '__' ) ) { function __( $text, $domain = null ) { return $text; } }
 if ( ! function_exists( 'sanitize_key' ) ) { function sanitize_key( $key ) { return strtolower( preg_replace( '/[^a-z0-9_\-]/', '', (string) $key ) ); } }

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,6 +1,18 @@
 <?php
-if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) { exit; }
-$options = array( 'unit', 'default_preset', 'max_drinks', 'show_abv' );
-foreach ( $options as $key ) {
-    delete_option( "mm_{$key}" );
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+    exit;
+}
+
+$options = array(
+    'mm_unit',
+    'mm_default_preset',
+    'mm_max_drinks',
+    'mm_show_abv',
+    'mm_standard_drink_region',
+    'mm_bottle_sizes',
+    'mm_custom_presets',
+);
+
+foreach ( $options as $option ) {
+    delete_option( $option );
 }


### PR DESCRIPTION
### Motivation
- Finalize release hygiene and documentation before submitting Margarita Measurements v3.0.0 to WordPress.org by cleaning up uninstall behavior, securing direct PHP access, aligning metadata and docs, ensuring translation/version consistency, and adding a minimal CI syntax check. 

### Description
- Update `uninstall.php` to keep the `WP_UNINSTALL_PLUGIN` guard and delete only plugin-owned options: `mm_unit`, `mm_default_preset`, `mm_max_drinks`, `mm_show_abv`, `mm_standard_drink_region`, `mm_bottle_sizes`, and `mm_custom_presets`.
- Add `ABSPATH` direct-access guards to production include files `includes/class-plugin.php`, `includes/class-calculator.php`, `includes/class-settings.php`, `includes/class-rest.php`, and `includes/class-ajax.php`, and update `tests/bootstrap.php` to define `ABSPATH` for PHPUnit bootstrapping.
- Add block editor dependency asset file `block/editor.asset.php` with the editor package dependencies and version `3.0.0`, and register block assets via the existing `block/` metadata (no build step introduced).
- Refresh metadata and docs: set Plugin URI to the existing GitHub repo in `margarita-measurements.php`, keep `Requires PHP: 8.1`, change `readme.txt` `Contributors:` to `TODO-wordpress-org-username`, trim screenshot list to present files, regenerate/patch POT header to `3.0.0`, rewrite `README.md` as a developer-facing landing page, and update `assets-wporg/README.md` to document SVN `assets/` expectations.
- Improve CI by adding a PHP syntax check step to `.github/workflows/release.yml` and add `block/editor.asset.php` to repo; no PHPUnit vendoring or WP-CLI installation was added.

### Testing
- Ran PHP syntax checks with `find . -name "*.php" -not -path "./dist/*" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l` which reported no syntax errors for checked files.
- Verified metadata/version text with `rg` searches for `Version`, `Stable tag`, `Requires PHP`, `Project-Id-Version`, and `Contributors` which confirmed `3.0.0`, `Requires PHP: 8.1`, POT header update, and `Contributors: TODO-wordpress-org-username`.
- Attempted `wp i18n make-pot` but `wp` (WP-CLI) was not available so only the POT header was updated and a full `wp i18n make-pot` run remains required in a WP-CLI environment.
- Attempted to run `phpunit -c tests/phpunit.xml` but `phpunit`/vendored test runner was not available so PHPUnit tests were not executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2de1a6a20c832bbeaab8ba21dfe979)