### PR TITLE
Improve admin UX and usage documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Margarita Measurements is a WordPress plugin for publishing an interactive margarita recipe calculator. Version 3.0.0 focuses on recipe ratios, batch scaling, flavour variations, ABV estimates, standard-drink estimates, and embeddable calculator views for WordPress content.
 
-For the WordPress.org directory-format listing, see [`readme.txt`](readme.txt). That file is the canonical plugin-directory readme for submission metadata, screenshots, FAQ, changelog, and upgrade notices.
+For practical shortcode and admin setup notes, see [`docs/USAGE.md`](docs/USAGE.md). For the WordPress.org directory-format listing, see [`readme.txt`](readme.txt). That file is the canonical plugin-directory readme for submission metadata, screenshots, FAQ, changelog, and upgrade notices.
 
 ## Features
 
@@ -18,6 +18,7 @@ For the WordPress.org directory-format listing, see [`readme.txt`](readme.txt). 
 - Nutrition and standard-drink estimates for AU, UK, and US standard-drink definitions.
 - Salt-rim estimate, print-friendly recipe card output, responsive styles, and dark-mode-aware CSS variables.
 - Local AJAX calculations and REST endpoints for calculation and preset data.
+- Visitor selections are not stored. The calculator does not use localStorage, cookies or user accounts to remember recipe choices.
 
 ## Requirements
 
@@ -72,6 +73,8 @@ The plugin registers a dynamic **Margarita Measurements** block. The block edito
 
 ## Settings summary
 
+The WordPress settings screen supports site-wide defaults. Site defaults apply when no shortcode or block override is provided, and shortcode or block settings override these defaults for that specific calculator instance.
+
 The WordPress settings screen supports:
 
 - Default unit.
@@ -84,7 +87,7 @@ The WordPress settings screen supports:
 
 ## Privacy and external services
 
-Margarita Measurements does not add analytics, tracking, visitor accounts, saved visitor recipes, URL sharing, remote API calls, or third-party calculation services. Recipe calculations run in the browser and through the plugin's local WordPress AJAX/REST handlers.
+Margarita Measurements does not add analytics, tracking, visitor accounts, saved visitor recipes, URL sharing, remote API calls, or third-party calculation services. Recipe calculations run in the browser and through the plugin's local WordPress AJAX/REST handlers. Visitor selections are not stored. The calculator does not use localStorage, cookies or user accounts to remember recipe choices.
 
 ## Architecture notes
 

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,0 +1,13 @@
+.mm-admin-wrap { max-width: 1180px; }
+.mm-admin-wrap h1 { margin-bottom: 1rem; }
+.mm-admin-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 16px; margin: 16px 0; }
+.mm-admin-card { background: #fff; border: 1px solid #c3c4c7; box-shadow: 0 1px 1px rgba(0,0,0,.04); padding: 18px 20px; margin: 16px 0; }
+.mm-admin-card h2 { margin-top: 0; }
+.mm-admin-card--primary { border-left: 4px solid #2271b1; }
+.mm-admin-code { display: block; box-sizing: border-box; width: 100%; max-width: 620px; margin: 8px 0; padding: 7px 10px; font-family: Consolas, Monaco, monospace; background: #f6f7f7; color: #1d2327; border: 1px solid #c3c4c7; border-radius: 3px; }
+.mm-admin-help { color: #50575e; font-size: 14px; max-width: 760px; }
+.mm-admin-actions { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; }
+.mm-admin-pill { display: inline-block; margin: 0 0 8px; padding: 3px 8px; border-radius: 999px; background: #f0f6fc; color: #135e96; font-size: 12px; font-weight: 600; }
+.mm-bottle-size-settings label { display: inline-block; min-width: 240px; margin-bottom: 8px; }
+.mm-bottle-size-settings input { width: 95px; }
+@media (max-width: 960px) { .mm-admin-grid { grid-template-columns: 1fr; } }

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,0 +1,103 @@
+# Margarita Measurements usage guide
+
+This guide covers the practical ways to embed Margarita Measurements and choose defaults for a WordPress site. For project overview, requirements, and release notes, see the main [README.md](../README.md).
+
+## Embedding the calculator
+
+1. Install the plugin by uploading the plugin ZIP in WordPress or by copying the repository folder to `wp-content/plugins/margarita-measurements`.
+2. Activate **Margarita Measurements** in **Plugins → Installed Plugins**.
+3. Add the full calculator shortcode to a post or page, insert the Gutenberg block, or use the compact widget shortcode in recipe content.
+4. Review site-wide defaults in **Settings → Margarita Measurements**.
+
+## Shortcode examples
+
+Full calculator with site defaults:
+
+```text
+[margarita_measurements]
+```
+
+Full calculator with a Tommy's preset, four drinks, and millilitres:
+
+```text
+[margarita_measurements preset="tommys" drinks="4" unit="ml"]
+```
+
+Full calculator with a flavour and ABV estimate visible:
+
+```text
+[margarita_measurements preset="classic" flavour="mango" drinks="6" show_abv="true"]
+```
+
+Full calculator with recipe-planning estimate options:
+
+```text
+[margarita_measurements preset="tommys" drinks="4" tequila_abv="38" standard_region="AU" show_nutrition="true"]
+```
+
+## Compact widget
+
+Use the compact widget when you want a smaller calculator inside recipe posts or side content.
+
+```text
+[margarita_widget]
+```
+
+```text
+[margarita_widget preset="classic" drinks="2" align="right"]
+```
+
+The widget supports defaults such as `preset`, `unit`, `drinks`, `flavour`, `title`, `show_abv`, `show_nutrition`, and `align`.
+
+## Common attributes
+
+Common shortcode attributes include:
+
+| Attribute | Example | Notes |
+| --- | --- | --- |
+| `preset` | `preset="tommys"` | Opens the calculator with a built-in or custom preset. |
+| `unit` | `unit="ml"` | Supports `ml`, `oz`, `shot`, and `nip`. |
+| `drinks` | `drinks="4"` | Initial drink count, limited by the Max Drinks setting. |
+| `flavour` | `flavour="mango"` | Opens with a flavour variation selected. |
+| `show_abv` | `show_abv="true"` | Overrides the site default for that calculator instance. |
+| `show_nutrition` | `show_nutrition="true"` | Shows nutrition and standard-drink estimates when supported. |
+| `tequila_abv` | `tequila_abv="38"` | Initial tequila ABV estimate value. |
+| `triple_sec_abv` | `triple_sec_abv="40"` | Initial triple sec ABV estimate value. |
+| `standard_region` | `standard_region="AU"` | Supports `AU`, `US`, and `UK`. |
+| `align` | `align="right"` | Widget alignment: `none`, `left`, `right`, or `center`. |
+
+## Admin defaults
+
+The settings page at **Settings → Margarita Measurements** controls site-wide defaults:
+
+- Default unit.
+- Default recipe preset.
+- Maximum drinks per calculation.
+- Whether estimated ABV is shown by default.
+- Standard-drink region for estimates.
+- Party-planning bottle sizes for tequila, triple sec, citrus, agave, and flavour mixers.
+- Custom presets stored as WordPress options for use in shortcodes, blocks, and the calculator UI.
+
+Site defaults apply when no shortcode or block override is provided. Shortcode and block settings override these defaults for that specific calculator instance.
+
+Nutrition, ABV and standard-drink values are estimates for recipe planning only.
+
+## Visitor selections and privacy
+
+Visitor choices are not saved. Calculator selections are used only for the current calculation. Use site defaults, shortcode attributes or block settings when you want a calculator to open with specific values.
+
+Visitor selections are not stored. The calculator does not use localStorage, cookies or user accounts to remember recipe choices.
+
+The plugin does not store visitor preferences, calculations, or recipe choices. It also does not add saved recipes, visitor accounts, favourites, URL sharing, analytics, or third-party calculation services.
+
+## Gutenberg block
+
+The plugin provides a dynamic **Margarita Measurements** block for the full calculator. Block attributes can set block-level defaults for a particular block instance. Those block-level defaults override site defaults for that instance only.
+
+## Troubleshooting
+
+- If a shortcode displays as plain text, confirm that it was added to a shortcode-capable content area.
+- If a preset is not selected, confirm the preset key is valid or create a custom preset in the settings screen.
+- If the drink count is lower than expected, check the **Max Drinks** setting.
+- If ABV is not visible, check the **Show ABV** setting or add `show_abv="true"` to that shortcode instance.
+- For bugs and support, use the [GitHub issues page](https://github.com/bchetcuti/margaritaWP/issues).

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -5,6 +5,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class MM_Settings {
     private static $instance = null;
+    private $settings_page_hook = '';
+
     public static function instance() {
         if ( null === self::$instance ) { self::$instance = new self(); }
         return self::$instance;
@@ -12,15 +14,22 @@ class MM_Settings {
     private function __construct() {
         add_action( 'admin_init', array( $this, 'register_settings' ) );
         add_action( 'admin_menu', array( $this, 'add_menu' ) );
+        add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_assets' ) );
     }
     public function add_menu() {
-        add_options_page(
+        $this->settings_page_hook = add_options_page(
             __( 'Margarita Measurements', 'margarita-measurements' ),
             __( 'Margarita Measurements', 'margarita-measurements' ),
             'manage_options',
             'margarita-measurements',
             array( $this, 'render_page' )
         );
+    }
+    public function enqueue_admin_assets( $hook_suffix ) {
+        if ( $hook_suffix !== $this->settings_page_hook ) {
+            return;
+        }
+        wp_enqueue_style( 'mm-admin', MM_PLUGIN_URL . 'assets/css/admin.css', array(), MM_VERSION );
     }
     public function register_settings() {
         register_setting( 'mm_settings', 'mm_unit', array( 'type' => 'string', 'sanitize_callback' => array( $this, 'sanitize_unit' ), 'default' => 'ml' ) );
@@ -82,96 +91,98 @@ class MM_Settings {
 
         return array_slice( $presets, 0, 20, true );
     }
-    public function render_page() {
+
+    private function shortcode_example( $shortcode ) {
         ?>
-        <div class="wrap">
+        <input class="mm-admin-code" type="text" readonly value="<?php echo esc_attr( $shortcode ); ?>" />
+        <?php
+    }
+
+    public function render_page() {
+        $repository_url = 'https://github.com/bchetcuti/margaritaWP';
+        $readme_url     = 'https://github.com/bchetcuti/margaritaWP#readme';
+        $issues_url     = 'https://github.com/bchetcuti/margaritaWP/issues';
+        ?>
+        <div class="wrap mm-admin-wrap">
             <h1><?php echo esc_html__( 'Margarita Measurements Settings', 'margarita-measurements' ); ?></h1>
-            <form method="post" action="options.php">
+            <div class="mm-admin-grid">
+                <section class="mm-admin-card mm-admin-card--primary">
+                    <p class="mm-admin-pill"><?php echo esc_html( sprintf( __( 'Version %s', 'margarita-measurements' ), MM_VERSION ) ); ?></p>
+                    <h2><?php esc_html_e( 'Overview', 'margarita-measurements' ); ?></h2>
+                    <p><?php esc_html_e( 'Margarita Measurements adds an interactive margarita calculator to WordPress with recipe presets, batch scaling, flavour variations, party-planning estimates, ABV estimates and compact recipe widgets.', 'margarita-measurements' ); ?></p>
+                    <p><?php esc_html_e( 'Embed it with the full calculator shortcode, the compact widget shortcode, or the Gutenberg block.', 'margarita-measurements' ); ?></p>
+                    <p class="mm-admin-help"><strong><?php esc_html_e( 'Visitor choices are not saved. Calculator selections are used only for the current calculation. Use site defaults, shortcode attributes or block settings when you want a calculator to open with specific values.', 'margarita-measurements' ); ?></strong></p>
+                </section>
+
+                <section class="mm-admin-card">
+                    <h2><?php esc_html_e( 'Quick start', 'margarita-measurements' ); ?></h2>
+                    <p><?php esc_html_e( 'Copy a shortcode into a post, page, widget area, or shortcode-capable template.', 'margarita-measurements' ); ?></p>
+                    <?php
+                    $this->shortcode_example( '[margarita_measurements]' );
+                    $this->shortcode_example( '[margarita_measurements preset="tommys" drinks="4" unit="ml"]' );
+                    $this->shortcode_example( '[margarita_measurements preset="classic" flavour="mango" drinks="6" show_abv="true"]' );
+                    $this->shortcode_example( '[margarita_widget]' );
+                    $this->shortcode_example( '[margarita_widget preset="classic" drinks="2" align="right"]' );
+                    ?>
+                </section>
+
+                <section class="mm-admin-card">
+                    <h2><?php esc_html_e( 'Documentation and support', 'margarita-measurements' ); ?></h2>
+                    <p><?php esc_html_e( 'Use the GitHub documentation for shortcode attributes, setup notes and issue reporting.', 'margarita-measurements' ); ?></p>
+                    <p class="mm-admin-actions">
+                        <a class="button button-secondary" href="<?php echo esc_url( $repository_url ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Repository', 'margarita-measurements' ); ?></a>
+                        <a class="button button-secondary" href="<?php echo esc_url( $readme_url ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'README', 'margarita-measurements' ); ?></a>
+                        <a class="button button-secondary" href="<?php echo esc_url( $issues_url ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Issues', 'margarita-measurements' ); ?></a>
+                    </p>
+                    <p class="mm-admin-help"><?php esc_html_e( 'WordPress.org submission is coming soon; use GitHub for current documentation and support.', 'margarita-measurements' ); ?></p>
+                </section>
+            </div>
+
+            <form method="post" action="options.php" class="mm-admin-card">
                 <?php settings_fields( 'mm_settings' ); ?>
+                <h2><?php esc_html_e( 'Site defaults', 'margarita-measurements' ); ?></h2>
+                <p class="mm-admin-help"><?php esc_html_e( 'Site defaults apply when no shortcode or block override is provided.', 'margarita-measurements' ); ?></p>
+                <p class="mm-admin-help"><?php esc_html_e( 'Shortcode and block settings override these defaults for that specific calculator instance.', 'margarita-measurements' ); ?></p>
+                <p class="mm-admin-help"><?php esc_html_e( 'Nutrition, ABV and standard-drink values are estimates for recipe planning only.', 'margarita-measurements' ); ?></p>
                 <table class="form-table" role="presentation">
-                    <tr>
-                        <th scope="row"><label for="mm_unit"><?php esc_html_e( 'Default Unit', 'margarita-measurements' ); ?></label></th>
-                        <td>
-                            <select id="mm_unit" name="mm_unit">
-                                <?php foreach ( array( 'ml','oz','shot','nip' ) as $u ): ?>
-                                    <option value="<?php echo esc_attr( $u ); ?>" <?php selected( get_option('mm_unit', 'ml'), $u ); ?>>
-                                        <?php echo esc_html( strtoupper( $u ) ); ?>
-                                    </option>
-                                <?php endforeach; ?>
-                            </select>
-                        </td>
-                    </tr>
-                    <tr>
-                        <th scope="row"><label for="mm_default_preset"><?php esc_html_e( 'Default Preset', 'margarita-measurements' ); ?></label></th>
-                        <td>
-                            <select id="mm_default_preset" name="mm_default_preset">
-                                <?php foreach ( MM_Plugin::instance()->calc->list_presets() as $p => $preset ): ?>
-                                    <option value="<?php echo esc_attr( $p ); ?>" <?php selected( get_option('mm_default_preset', 'classic'), $p ); ?>>
-                                        <?php echo esc_html( $preset['label'] ?? ucfirst( $p ) ); ?>
-                                    </option>
-                                <?php endforeach; ?>
-                            </select>
-                        </td>
-                    </tr>
-                    <tr>
-                        <th scope="row"><label for="mm_max_drinks"><?php esc_html_e( 'Max Drinks (per calc)', 'margarita-measurements' ); ?></label></th>
-                        <td><input type="number" id="mm_max_drinks" name="mm_max_drinks" min="1" max="200" value="<?php echo esc_attr( get_option('mm_max_drinks', 25) ); ?>" /></td>
-                    </tr>
-                    <tr>
-                        <th scope="row"><?php esc_html_e( 'Show ABV', 'margarita-measurements' ); ?></th>
-                        <td><input type="checkbox" name="mm_show_abv" value="1" <?php checked( get_option('mm_show_abv', 1 ), 1 ); ?> /></td>
-                    </tr>
-                    <tr>
-                        <th scope="row"><label for="mm_standard_drink_region"><?php esc_html_e( 'Standard drink default', 'margarita-measurements' ); ?></label></th>
-                        <td><select id="mm_standard_drink_region" name="mm_standard_drink_region"><?php foreach ( array( 'AU' => 'Australia (10g)', 'US' => 'United States (14g)', 'UK' => 'United Kingdom (8g)' ) as $region => $label ) : ?><option value="<?php echo esc_attr( $region ); ?>" <?php selected( get_option( 'mm_standard_drink_region', 'AU' ), $region ); ?>><?php echo esc_html( $label ); ?></option><?php endforeach; ?></select></td>
-                    </tr>
-                    <?php $mm_bottle_sizes = MM_Plugin::instance()->calc->bottle_sizes(); ?>
-                    <tr>
-                        <th scope="row"><?php esc_html_e( 'Party bottle sizes (ml)', 'margarita-measurements' ); ?></th>
-                        <td class="mm-bottle-size-settings">
-                            <?php foreach ( array( 'tequila' => 'Tequila', 'triple' => 'Triple sec', 'citrus' => 'Citrus juice', 'agave' => 'Agave syrup', 'mixer' => 'Flavour mixers' ) as $key => $label ) : ?>
-                                <label><?php echo esc_html( $label ); ?> <input type="number" name="mm_bottle_sizes[<?php echo esc_attr( $key ); ?>]" min="50" max="5000" step="50" value="<?php echo esc_attr( $mm_bottle_sizes[ $key ] ); ?>" /></label><br />
-                            <?php endforeach; ?>
-                        </td>
-                    </tr>
+                    <tr><th scope="row"><label for="mm_unit"><?php esc_html_e( 'Default Unit', 'margarita-measurements' ); ?></label></th><td><select id="mm_unit" name="mm_unit"><?php foreach ( array( 'ml','oz','shot','nip' ) as $u ): ?><option value="<?php echo esc_attr( $u ); ?>" <?php selected( get_option('mm_unit', 'ml'), $u ); ?>><?php echo esc_html( strtoupper( $u ) ); ?></option><?php endforeach; ?></select><p class="description"><?php esc_html_e( 'The unit shown when no shortcode or block unit is provided.', 'margarita-measurements' ); ?></p></td></tr>
+                    <tr><th scope="row"><label for="mm_default_preset"><?php esc_html_e( 'Default Preset', 'margarita-measurements' ); ?></label></th><td><select id="mm_default_preset" name="mm_default_preset"><?php foreach ( MM_Plugin::instance()->calc->list_presets() as $p => $preset ): ?><option value="<?php echo esc_attr( $p ); ?>" <?php selected( get_option('mm_default_preset', 'classic'), $p ); ?>><?php echo esc_html( $preset['label'] ?? ucfirst( $p ) ); ?></option><?php endforeach; ?></select><p class="description"><?php esc_html_e( 'The recipe preset used by default.', 'margarita-measurements' ); ?></p></td></tr>
+                    <tr><th scope="row"><label for="mm_max_drinks"><?php esc_html_e( 'Max Drinks', 'margarita-measurements' ); ?></label></th><td><input type="number" id="mm_max_drinks" name="mm_max_drinks" min="1" max="200" value="<?php echo esc_attr( get_option('mm_max_drinks', 25) ); ?>" /><p class="description"><?php esc_html_e( 'Upper limit for drink-count calculations.', 'margarita-measurements' ); ?></p></td></tr>
+                    <tr><th scope="row"><?php esc_html_e( 'Show ABV', 'margarita-measurements' ); ?></th><td><label><input type="checkbox" name="mm_show_abv" value="1" <?php checked( get_option('mm_show_abv', 1 ), 1 ); ?> /> <?php esc_html_e( 'Show estimated ABV by default.', 'margarita-measurements' ); ?></label><p class="description"><?php esc_html_e( 'Show estimated ABV by default. Individual shortcode or block instances can override this.', 'margarita-measurements' ); ?></p></td></tr>
+                    <tr><th scope="row"><label for="mm_standard_drink_region"><?php esc_html_e( 'Standard drink default', 'margarita-measurements' ); ?></label></th><td><select id="mm_standard_drink_region" name="mm_standard_drink_region"><?php foreach ( array( 'AU' => 'Australia (10g)', 'US' => 'United States (14g)', 'UK' => 'United Kingdom (8g)' ) as $region => $label ) : ?><option value="<?php echo esc_attr( $region ); ?>" <?php selected( get_option( 'mm_standard_drink_region', 'AU' ), $region ); ?>><?php echo esc_html( $label ); ?></option><?php endforeach; ?></select><p class="description"><?php esc_html_e( 'Default standard-drink region for estimates.', 'margarita-measurements' ); ?></p></td></tr>
                 </table>
+
+                <h2><?php esc_html_e( 'Party planning defaults', 'margarita-measurements' ); ?></h2>
+                <p class="mm-admin-help"><?php esc_html_e( 'Used by Party Planning mode to estimate bottle counts.', 'margarita-measurements' ); ?></p>
+                <?php $mm_bottle_sizes = MM_Plugin::instance()->calc->bottle_sizes(); ?>
+                <table class="form-table" role="presentation"><tr><th scope="row"><?php esc_html_e( 'Party bottle sizes (ml)', 'margarita-measurements' ); ?></th><td class="mm-bottle-size-settings"><?php foreach ( array( 'tequila' => 'Tequila', 'triple' => 'Triple sec', 'citrus' => 'Citrus juice', 'agave' => 'Agave syrup', 'mixer' => 'Flavour mixers' ) as $key => $label ) : ?><label><?php echo esc_html( $label ); ?> <input type="number" name="mm_bottle_sizes[<?php echo esc_attr( $key ); ?>]" min="50" max="5000" step="50" value="<?php echo esc_attr( $mm_bottle_sizes[ $key ] ); ?>" /></label><br /><?php endforeach; ?><p class="description"><?php esc_html_e( 'Used by Party Planning mode to estimate bottle counts.', 'margarita-measurements' ); ?></p></td></tr></table>
                 <?php submit_button(); ?>
             </form>
 
-            <hr />
-            <h2><?php esc_html_e( 'Custom Presets', 'margarita-measurements' ); ?></h2>
-            <?php $custom_presets = get_option( 'mm_custom_presets', array() ); $custom_presets = is_array( $custom_presets ) ? $custom_presets : array(); ?>
-            <table class="widefat striped" style="max-width: 900px;">
-                <thead><tr><th><?php esc_html_e( 'Name', 'margarita-measurements' ); ?></th><th><?php esc_html_e( 'Ratios', 'margarita-measurements' ); ?></th><th><?php esc_html_e( 'Action', 'margarita-measurements' ); ?></th></tr></thead>
-                <tbody>
-                    <?php if ( empty( $custom_presets ) ) : ?>
-                        <tr><td colspan="3"><?php esc_html_e( 'No custom presets yet.', 'margarita-measurements' ); ?></td></tr>
-                    <?php else : ?>
-                        <?php foreach ( $custom_presets as $key => $preset ) : ?>
-                            <tr>
-                                <td><?php echo esc_html( $preset['label'] ?? ucfirst( $key ) ); ?></td>
-                                <td><?php echo esc_html( sprintf( 'Tequila %s ml, Citrus %s ml, Triple %s ml, Agave %s ml, Triple ABV %s%%, Ice x%s', $preset['tequila_ml'] ?? 0, $preset['citrus_ml'] ?? 0, $preset['triple_ml'] ?? 0, $preset['agave_ml'] ?? 0, round( ( $preset['triple_abv'] ?? 0.4 ) * 100, 1 ), $preset['ice_factor'] ?? 1 ) ); ?></td>
-                                <td><button type="button" class="button mm-delete-preset" data-key="<?php echo esc_attr( $key ); ?>"><?php esc_html_e( 'Delete', 'margarita-measurements' ); ?></button></td>
-                            </tr>
-                        <?php endforeach; ?>
-                    <?php endif; ?>
-                </tbody>
-            </table>
-            <h3><?php esc_html_e( 'Add preset', 'margarita-measurements' ); ?></h3>
-            <form method="post" action="options.php">
-                <?php settings_fields( 'mm_custom_presets_settings' ); wp_nonce_field( 'mm_custom_preset_nonce', 'mm_custom_preset_nonce' ); ?>
-                <table class="form-table" role="presentation">
-                    <tr><th><label for="mm_custom_label"><?php esc_html_e( 'Label', 'margarita-measurements' ); ?></label></th><td><input id="mm_custom_label" name="mm_custom_presets[new][label]" type="text" required /></td></tr>
-                    <tr><th><label for="mm_custom_tequila"><?php esc_html_e( 'Tequila ml', 'margarita-measurements' ); ?></label></th><td><input id="mm_custom_tequila" name="mm_custom_presets[new][tequila_ml]" type="number" min="0" step="0.1" value="60" /></td></tr>
-                    <tr><th><label for="mm_custom_citrus"><?php esc_html_e( 'Citrus ml', 'margarita-measurements' ); ?></label></th><td><input id="mm_custom_citrus" name="mm_custom_presets[new][citrus_ml]" type="number" min="0" step="0.1" value="25" /></td></tr>
-                    <tr><th><label for="mm_custom_triple"><?php esc_html_e( 'Triple sec ml', 'margarita-measurements' ); ?></label></th><td><input id="mm_custom_triple" name="mm_custom_presets[new][triple_ml]" type="number" min="0" step="0.1" value="15" /></td></tr>
-                    <tr><th><label for="mm_custom_agave"><?php esc_html_e( 'Agave ml', 'margarita-measurements' ); ?></label></th><td><input id="mm_custom_agave" name="mm_custom_presets[new][agave_ml]" type="number" min="0" step="0.1" value="5" /></td></tr>
-                    <tr><th><label for="mm_custom_abv"><?php esc_html_e( 'Triple sec ABV %', 'margarita-measurements' ); ?></label></th><td><input id="mm_custom_abv" name="mm_custom_presets[new][triple_abv]" type="number" min="0" max="100" step="0.1" value="40" /></td></tr>
-                    <tr><th><label for="mm_custom_ice"><?php esc_html_e( 'Ice factor', 'margarita-measurements' ); ?></label></th><td><input id="mm_custom_ice" name="mm_custom_presets[new][ice_factor]" type="number" min="0" step="0.1" value="1.0" /></td></tr>
-                    <tr><th><label for="mm_custom_note"><?php esc_html_e( 'Note', 'margarita-measurements' ); ?></label></th><td><input id="mm_custom_note" name="mm_custom_presets[new][note]" type="text" /></td></tr>
+            <section class="mm-admin-card">
+                <h2><?php esc_html_e( 'Custom Presets', 'margarita-measurements' ); ?></h2>
+                <p class="mm-admin-help"><?php esc_html_e( 'Create site-specific margarita ratios. These are stored as WordPress options and are available in shortcodes, blocks and the calculator UI.', 'margarita-measurements' ); ?></p>
+                <?php $custom_presets = get_option( 'mm_custom_presets', array() ); $custom_presets = is_array( $custom_presets ) ? $custom_presets : array(); ?>
+                <table class="widefat striped">
+                    <thead><tr><th><?php esc_html_e( 'Name', 'margarita-measurements' ); ?></th><th><?php esc_html_e( 'Ratios', 'margarita-measurements' ); ?></th><th><?php esc_html_e( 'Action', 'margarita-measurements' ); ?></th></tr></thead>
+                    <tbody><?php if ( empty( $custom_presets ) ) : ?><tr><td colspan="3"><?php esc_html_e( 'No custom presets yet.', 'margarita-measurements' ); ?></td></tr><?php else : foreach ( $custom_presets as $key => $preset ) : ?><tr><td><?php echo esc_html( $preset['label'] ?? ucfirst( $key ) ); ?></td><td><?php echo esc_html( sprintf( 'Tequila %s ml, Citrus %s ml, Triple %s ml, Agave %s ml, Triple ABV %s%%, Ice x%s', $preset['tequila_ml'] ?? 0, $preset['citrus_ml'] ?? 0, $preset['triple_ml'] ?? 0, $preset['agave_ml'] ?? 0, round( ( $preset['triple_abv'] ?? 0.4 ) * 100, 1 ), $preset['ice_factor'] ?? 1 ) ); ?></td><td><button type="button" class="button mm-delete-preset" data-key="<?php echo esc_attr( $key ); ?>"><?php esc_html_e( 'Delete', 'margarita-measurements' ); ?></button></td></tr><?php endforeach; endif; ?></tbody>
                 </table>
-                <?php submit_button( __( 'Save Custom Preset', 'margarita-measurements' ) ); ?>
-            </form>
+                <h3><?php esc_html_e( 'Add custom preset', 'margarita-measurements' ); ?></h3>
+                <form method="post" action="options.php">
+                    <?php settings_fields( 'mm_custom_presets_settings' ); wp_nonce_field( 'mm_custom_preset_nonce', 'mm_custom_preset_nonce' ); ?>
+                    <table class="form-table" role="presentation">
+                        <tr><th><label for="mm_custom_label"><?php esc_html_e( 'Label', 'margarita-measurements' ); ?></label></th><td><input id="mm_custom_label" name="mm_custom_presets[new][label]" type="text" required /><p class="description"><?php esc_html_e( 'Shown in preset dropdowns.', 'margarita-measurements' ); ?></p></td></tr>
+                        <tr><th><label for="mm_custom_tequila"><?php esc_html_e( 'Tequila ml', 'margarita-measurements' ); ?></label></th><td><input id="mm_custom_tequila" name="mm_custom_presets[new][tequila_ml]" type="number" min="0" step="0.1" value="60" /></td></tr>
+                        <tr><th><label for="mm_custom_citrus"><?php esc_html_e( 'Citrus ml', 'margarita-measurements' ); ?></label></th><td><input id="mm_custom_citrus" name="mm_custom_presets[new][citrus_ml]" type="number" min="0" step="0.1" value="25" /></td></tr>
+                        <tr><th><label for="mm_custom_triple"><?php esc_html_e( 'Triple sec ml', 'margarita-measurements' ); ?></label></th><td><input id="mm_custom_triple" name="mm_custom_presets[new][triple_ml]" type="number" min="0" step="0.1" value="15" /></td></tr>
+                        <tr><th><label for="mm_custom_agave"><?php esc_html_e( 'Agave ml', 'margarita-measurements' ); ?></label></th><td><input id="mm_custom_agave" name="mm_custom_presets[new][agave_ml]" type="number" min="0" step="0.1" value="5" /></td></tr>
+                        <tr><th><label for="mm_custom_abv"><?php esc_html_e( 'Triple sec ABV %', 'margarita-measurements' ); ?></label></th><td><input id="mm_custom_abv" name="mm_custom_presets[new][triple_abv]" type="number" min="0" max="100" step="0.1" value="40" /></td></tr>
+                        <tr><th><label for="mm_custom_ice"><?php esc_html_e( 'Ice factor', 'margarita-measurements' ); ?></label></th><td><input id="mm_custom_ice" name="mm_custom_presets[new][ice_factor]" type="number" min="0" step="0.1" value="1.0" /></td></tr>
+                        <tr><th><label for="mm_custom_note"><?php esc_html_e( 'Note', 'margarita-measurements' ); ?></label></th><td><input id="mm_custom_note" name="mm_custom_presets[new][note]" type="text" /></td></tr>
+                    </table>
+                    <?php submit_button( __( 'Save Custom Preset', 'margarita-measurements' ) ); ?>
+                </form>
+            </section>
             <script>
             jQuery(function($){
                 $('.mm-delete-preset').on('click', function(){

--- a/readme.txt
+++ b/readme.txt
@@ -13,7 +13,7 @@ A margarita calculator for WordPress with recipe ratios, batch scaling, flavour 
 == Description ==
 Whether you're squeezing limes for two or mixing a larger batch for guests, Margarita Measurements does the maths so you don't have to.
 
-Margarita Measurements helps WordPress sites publish a practical cocktail calculator with preset recipes, unit conversion, flavour variations, pitcher/batch output, print-friendly results, and responsible recipe-planning estimates.
+Margarita Measurements helps WordPress sites publish a practical cocktail calculator with preset recipes, unit conversion, flavour variations, pitcher/batch output, print-friendly results, and practical recipe-planning estimates.
 
 = Who it is for =
 * Home users: scale a classic, Tommy's, frozen or skinny margarita without mental arithmetic.
@@ -37,6 +37,7 @@ Margarita Measurements helps WordPress sites publish a practical cocktail calcul
 * Themeable CSS variables with dark mode support.
 * AJAX form with no page reload.
 * REST endpoint for calculations and preset listings.
+* Visitor selections are not stored; the calculator does not use localStorage, cookies or user accounts to remember recipe choices.
 
 = Shortcodes =
 `[margarita_measurements]`
@@ -50,7 +51,7 @@ Margarita Measurements helps WordPress sites publish a practical cocktail calcul
 `[margarita_widget preset="classic" drinks="2" align="right"]`
 
 = Privacy =
-Recipe calculations run in WordPress and the browser through the plugin's local AJAX/REST handlers. The plugin does not send recipe calculations to third-party services, does not add analytics, and does not track visitors.
+Recipe calculations run in WordPress and the browser through the plugin's local AJAX/REST handlers. The plugin does not send recipe calculations to third-party services, does not add analytics, and does not track visitors. Visitor selections are not stored. The calculator does not use localStorage, cookies or user accounts to remember recipe choices.
 
 == Installation ==
 1. Upload the ZIP via Plugins > Add New > Upload Plugin.
@@ -80,13 +81,17 @@ Yes. The Advanced panel includes tequila and triple sec ABV fields, and the shor
 Yes. The nutrition panel estimates alcohol grams and standard drinks using AU (10g), UK (8g) or US (14g) definitions. These are approximate recipe-planning values only.
 
 = Does it store visitor data? =
-No. The plugin does not store visitor recipe calculations or visitor account data.
+No. Visitor selections are not stored. The calculator does not use localStorage, cookies or user accounts to remember recipe choices.
 
 = Does it call third-party services? =
 No. It does not call third-party APIs or load remote tracking services for calculations.
 
 == Changelog ==
 = 3.0.0 =
+* Improved the WordPress admin settings screen with clearer setup guidance.
+* Added shortcode and widget examples to the admin page.
+* Added GitHub documentation and support links.
+* Clarified that visitor calculator selections are not stored.
 * Added nutrition and standard drinks estimator.
 * Added AU, UK and US standard-drink region support.
 * Added tequila and triple sec ABV customisation.
@@ -112,7 +117,7 @@ No. It does not call third-party APIs or load remote tracking services for calcu
 
 == Upgrade Notice ==
 = 3.0.0 =
-Adds responsible recipe-planning estimates, ABV customisation and a compact widget shortcode for recipe posts.
+Adds practical recipe-planning estimates, ABV customisation and a compact widget shortcode for recipe posts.
 
 == License ==
 GPLv2 or later.


### PR DESCRIPTION
### Motivation

- Make the Margarita Measurements admin settings clearer and more helpful to site owners by grouping controls and explanatory copy into familiar WordPress admin patterns. 
- Provide copyable shortcode/widget examples and a documentation card so owners can quickly embed the calculator and find support. 
- Clarify privacy and defaults: emphasize that visitor selections are temporary and not persisted, and explain how site defaults, shortcode attributes and block settings interact. 

### Description

- Refactored the settings screen in `includes/class-settings.php` into clear sections: `Overview`, `Quick start`, `Documentation and support`, `Site defaults`, `Party planning defaults`, and `Custom Presets`, and added concise helper text describing defaults vs per-instance overrides. 
- Added copyable shortcode examples via a small `shortcode_example()` helper and improved field descriptions for `mm_unit`, `mm_default_preset`, `mm_max_drinks`, `mm_show_abv`, `mm_standard_drink_region`, party `mm_bottle_sizes`, and custom presets while keeping existing option names and sanitizers. 
- Added admin-only styling in `assets/css/admin.css` and enqueue logic that only loads the stylesheet on the plugin settings page using the settings page hook and `admin_enqueue_scripts`. 
- Created `docs/USAGE.md` with practical installation, shortcode/widget examples, attributes, admin defaults, Gutenberg notes and a privacy statement; updated `README.md` and `readme.txt` to link to the usage doc and explicitly state that visitor selections are not stored. 
- Kept existing sanitisation, nonce checks and AJAX preset-deletion flow; external links use `esc_url()` and open with `rel="noopener noreferrer"`.

### Testing

- Ran PHP syntax checks with `find . -name "*.php" ... | xargs -0 -n1 php -l` and all PHP files reported no syntax errors. 
- Attempted to run PHPUnit but the environment does not provide `phpunit` (test runner unavailable). 
- Searched the codebase for persistence-related keywords and confirmed the messaging and no-storage language were added and no new localStorage/cookie/user_meta usage was introduced. 
- Ran `git diff --check` style checks and the repository passed without whitespace/syntax diffs; manual WordPress admin/front-end QA was not performed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e60c24c28832babad271d6b6699b2)